### PR TITLE
Return list of failing types along with result

### DIFF
--- a/src/NetArchTest.Rules/ConditionList.cs
+++ b/src/NetArchTest.Rules/ConditionList.cs
@@ -33,19 +33,28 @@
         /// <summary>
         /// Returns an indication of whether all the selected types satisfy the conditions.
         /// </summary>
-        /// <returns>An indication of whether the conditions are true.</returns>
-        public bool GetResult()
+        /// <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
+        public TestResult GetResult()
         {
+            bool success;
             if (_should)
             {
                 // All the classes should meet the condition
-                return (_sequence.Execute(_types).Count() == _types.Count());
+                success = (_sequence.Execute(_types).Count() == _types.Count());
             }
             else
             {
                 // No classes should meet the condition
-                return (!_sequence.Execute(_types).Any());
+                success = (!_sequence.Execute(_types).Any());
             }
+
+            if (success)
+            {
+                return TestResult.Success();
+            }
+
+            // If we've failed, get a collection of failing types so these can be reported in a failing test.
+            return TestResult.Failure(_sequence.Execute(_types, selected: false).Select(t => t.ToType()));
         }
 
         /// <summary>

--- a/src/NetArchTest.Rules/FunctionSequence.cs
+++ b/src/NetArchTest.Rules/FunctionSequence.cs
@@ -41,8 +41,8 @@
         /// <summary>
         /// Executes all the function calls that have been specified.
         /// </summary>
-        /// <returns>A list of types that are selected by the predicates.</returns>
-        internal IEnumerable<TypeDefinition> Execute(IEnumerable<TypeDefinition> input)
+        /// <returns>A list of types that are selected by the predicates (or not selected if optional reversing flag is passed).</returns>
+        internal IEnumerable<TypeDefinition> Execute(IEnumerable<TypeDefinition> input, bool selected = true)
         {
             var resultSets = new List<List<TypeDefinition>>();
 
@@ -59,7 +59,7 @@
                 // Invoke the functions iteratively - functions within a group are treated as "and" statements
                 foreach (var func in group)
                 {
-                    var funcResults = func.FunctionDelegate.DynamicInvoke(results, func.Value, func.Condition) as IEnumerable<TypeDefinition>;
+                    var funcResults = func.FunctionDelegate.DynamicInvoke(results, func.Value, selected ? func.Condition : !func.Condition) as IEnumerable<TypeDefinition>;
                     results = funcResults.ToList();
                 }
 

--- a/src/NetArchTest.Rules/NetArchTest.Rules.csproj
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.csproj
@@ -16,11 +16,11 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>D:\Work\NetArchTest\src\NetArchTest.Rules\NetArchTest.Rules.xml</DocumentationFile>
+    <DocumentationFile>NetArchTest.Rules.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>D:\Work\NetArchTest\src\NetArchTest.Rules\NetArchTest.Rules.xml</DocumentationFile>
+    <DocumentationFile>NetArchTest.Rules.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -27,7 +27,7 @@
             <summary>
             Returns an indication of whether all the selected types satisfy the conditions.
             </summary>
-            <returns>An indication of whether the conditions are true.</returns>
+            <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
         </member>
         <member name="M:NetArchTest.Rules.ConditionList.Count">
             <summary>
@@ -502,11 +502,11 @@
             Creates a new logical grouping of function calls.
             </summary>
         </member>
-        <member name="M:NetArchTest.Rules.FunctionSequence.Execute(System.Collections.Generic.IEnumerable{Mono.Cecil.TypeDefinition})">
+        <member name="M:NetArchTest.Rules.FunctionSequence.Execute(System.Collections.Generic.IEnumerable{Mono.Cecil.TypeDefinition},System.Boolean)">
             <summary>
             Executes all the function calls that have been specified.
             </summary>
-            <returns>A list of types that are selected by the predicates.</returns>
+            <returns>A list of types that are selected by the predicates (or not selected if optional reversing flag is passed).</returns>
         </member>
         <member name="T:NetArchTest.Rules.FunctionSequence.FunctionCall">
             <summary>
@@ -821,6 +821,33 @@
             </summary>
             <param name="dependency">The dependency type to match against.</param>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="T:NetArchTest.Rules.TestResult">
+            <summary>
+            Defines a result from a test carried out on a <see cref="T:NetArchTest.Rules.ConditionList"/>.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.TestResult.IsSuccessful">
+            <summary>
+            Flag indicating the success or failure of the test.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.TestResult.FailingTypes">
+            <summary>
+            Collection populated with a list of types that failed the test, if the test was a failure.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.TestResult.Success">
+            <summary>
+            Creates a new instance of <see cref="T:NetArchTest.Rules.TestResult"/> indicating a successful test.
+            </summary>
+            <returns>Instance of <see cref="T:NetArchTest.Rules.TestResult"/></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.TestResult.Failure(System.Collections.Generic.IEnumerable{System.Type})">
+            <summary>
+            Creates a new instance of <see cref="T:NetArchTest.Rules.TestResult"/> indicating a failed test.
+            </summary>
+            <returns>Instance of <see cref="T:NetArchTest.Rules.TestResult"/></returns>
         </member>
         <member name="T:NetArchTest.Rules.Types">
             <summary>

--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -1,0 +1,50 @@
+﻿namespace NetArchTest.Rules
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Defines a result from a test carried out on a <see cref="ConditionList"/>.
+    /// </summary>
+    public class TestResult
+    {
+        private TestResult()
+        {
+        }
+
+        /// <summary>
+        /// Flag indicating the success or failure of the test.
+        /// </summary>
+        public bool IsSuccessful { get; private set; }
+
+        /// <summary>
+        /// Collection populated with a list of types that failed the test, if the test was a failure.
+        /// </summary>
+        public IEnumerable<Type> FailingTypes { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TestResult"/> indicating a successful test.
+        /// </summary>
+        /// <returns>Instance of <see cref="TestResult"/></returns>
+        public static TestResult Success()
+        {
+            return new TestResult
+            {
+                IsSuccessful = true
+            };
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TestResult"/> indicating a failed test.
+        /// </summary>
+        /// <returns>Instance of <see cref="TestResult"/></returns>
+        public static TestResult Failure(IEnumerable<Type> failingTypes)
+        {
+            return new TestResult
+            {
+                IsSuccessful = false,
+                FailingTypes = failingTypes
+            };
+        }
+    }
+}

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace NetArchTest.Rules.UnitTests
 {
+    using System.Linq;
     using System.Reflection;
     using NetArchTest.TestStructure.CustomAttributes;
-    using NetArchTest.TestStructure.Dependencies;
     using NetArchTest.TestStructure.Inheritance;
     using NetArchTest.TestStructure.Interfaces;
     using NetArchTest.TestStructure.NameMatching.Namespace1;
@@ -20,7 +20,7 @@
                 .Should()
                 .HaveName("ClassB2").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not have a specific name.")]
@@ -33,7 +33,7 @@
                 .Should()
                 .NotHaveName("ClassB2").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected by the start of their name.")]
@@ -46,7 +46,7 @@
                 .Should()
                 .HaveNameStartingWith("Class").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if their name does not have a specific start.")]
@@ -59,7 +59,7 @@
                 .Should()
                 .NotHaveNameStartingWith("X").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected by the end of their name.")]
@@ -72,7 +72,7 @@
                 .Should()
                 .HaveNameEndingWith("B2").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if their name does not have a specific end.")]
@@ -85,7 +85,7 @@
                 .Should()
                 .NotHaveNameEndingWith("B2").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected by a regular expression.")]
@@ -98,7 +98,7 @@
                 .Should()
                 .HaveNameMatching(@"Class\w\d").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not conform to a regular expression.")]
@@ -111,7 +111,7 @@
                 .Should()
                 .NotHaveNameMatching(@"X\w").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected by a the presence of a custom attribute.")]
@@ -126,7 +126,7 @@
                 .Should()
                 .HaveCustomAttribute(typeof(ClassCustomAttribute)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected by the absence of a custom attribute.")]
@@ -141,7 +141,7 @@
                 .Should()
                 .NotHaveCustomAttribute(typeof(ClassCustomAttribute)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they inherit from a type.")]
@@ -156,7 +156,7 @@
                 .Should()
                 .Inherit(typeof(BaseClass)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not inherit from a type.")]
@@ -171,7 +171,7 @@
                 .Should()
                 .NotInherit(typeof(BaseClass)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they implement an interface.")]
@@ -186,7 +186,7 @@
                 .Should()
                 .ImplementInterface(typeof(IExample)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not implement an interface.")]
@@ -201,7 +201,7 @@
                 .Should()
                 .NotImplementInterface(typeof(IExample)).GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are abstract.")]
@@ -216,7 +216,7 @@
                 .Should()
                 .BeAbstract().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are not abstract.")]
@@ -231,7 +231,7 @@
                 .Should()
                 .NotBeAbstract().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are classes.")]
@@ -246,7 +246,7 @@
                 .Should()
                 .BeClasses().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are not classes.")]
@@ -261,7 +261,7 @@
                 .Should()
                 .NotBeClasses().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they have generic parameters.")]
@@ -276,7 +276,7 @@
                 .Should()
                 .BeGeneric().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not have generic parameters.")]
@@ -291,7 +291,7 @@
                 .Should()
                 .NotBeGeneric().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are interfaces.")]
@@ -306,7 +306,7 @@
                 .Should()
                 .BeInterfaces().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are not interfaces.")]
@@ -321,7 +321,7 @@
                 .Should()
                 .NotBeInterfaces().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are nested.")]
@@ -336,7 +336,7 @@
                 .Should()
                 .BeNested().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they are not nested.")]
@@ -351,7 +351,7 @@
                 .Should()
                 .NotBeNested().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected for being declared as public.")]
@@ -366,7 +366,7 @@
                 .Should()
                 .BePublic().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected for not being declared as public.")]
@@ -381,7 +381,7 @@
                 .Should()
                 .NotBePublic().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected for being declared as sealed.")]
@@ -396,7 +396,7 @@
                 .Should()
                 .BeSealed().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected for not being declared as sealed.")]
@@ -411,7 +411,7 @@
                 .Should()
                 .NotBeSealed().GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]
@@ -424,7 +424,7 @@
                 .Should()
                 .ResideInNamespace("NetArchTest.TestStructure.NameMatching").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not reside in a namespace.")]
@@ -437,7 +437,7 @@
                 .Should()
                 .NotResideInNamespace("NetArchTest.TestStructure.Wrong").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Selecting by namespace will return types in nested namespaces.")]
@@ -450,7 +450,7 @@
                 .Should()
                 .ResideInNamespace("NetArchTest.TestStructure.NameMatching").GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they have a dependency on another type.")]
@@ -466,7 +466,7 @@
                 .HaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
                 .GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not have a dependency on another type.")]
@@ -482,7 +482,26 @@
                 .NotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
                 .GetResult();
 
-            Assert.True(result);
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types failing condition are reported when test fails.")]
+        public void MatchNotFound_ClassesReported()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.NameMatching.Namespace1")
+                .Should()
+                .HaveName("ClassA2")
+                .GetResult();
+
+            Assert.False(result.IsSuccessful);
+
+            var failingTypes = result.FailingTypes.ToList();
+            Assert.Equal(2, failingTypes.Count);
+            Assert.Equal("NetArchTest.TestStructure.NameMatching.Namespace1.ClassA1", failingTypes[0].ToString());
+            Assert.Equal("NetArchTest.TestStructure.NameMatching.Namespace1.ClassB1", failingTypes[1].ToString());
         }
     }
 }


### PR DESCRIPTION
Thanks for sharing this, looks very useful.  I've [looked to do something similar recently](https://web-matters.blogspot.com/2018/02/verification-of-sitecore-helix-architecture-fitness-function.html), at the assembly level though, in the context of a Sitecore project, looking to adhere to certain solution structure rules known as the "Helix" architecture.  

For this PR though, I thought that in the context of a test that's looking to verify the architecture (fitness function style) it would be handy to get back a list of types that have failed the test, so you can then be directed to the problem area to fix.  That could then be used in a custom message to the failing test, perhaps using [fluent assertions](https://fluentassertions.com/documentation/).

So that's what I've implemented here, by changing the result type from a boolean to a class that contains the success flag and the list of failing types.  