### PR TITLE
Adding predicates and conditions to check mutability/immutability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,8 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Visual Studio Code files
+*.code-workspace
+launch.json
+tasks.json

--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -335,6 +335,26 @@
         }
 
         /// <summary>
+        /// Selects types according that are immutable.
+        /// </summary>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList BeImmutable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeImmutable, true, true);
+            return new ConditionList(_types, _should, _sequence);
+        }
+
+        /// <summary>
+        /// Selects types according that are mutable.
+        /// </summary>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList BeMutable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeImmutable, true, false);
+            return new ConditionList(_types, _should, _sequence);
+        }
+
+        /// <summary>
         /// Selects types that reside in a particular namespace.
         /// </summary>
         /// <param name="name">The namespace to match against.</param>

--- a/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
@@ -1,0 +1,23 @@
+namespace NetArchTest.Rules.Extensions
+{
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Mono.Cecil;
+
+    /// <summary>
+    /// Extensions for the <see cref="FieldDefinition"/> class.
+    /// </summary>
+    static internal class FieldDefinitionExtensions
+    {
+        /// <summary>
+        /// Tests whether a field is readonly
+        /// </summary>
+        /// <param name="fieldDefinition">The field to test.</param>
+        /// <returns>An indication of whether the field is readonly.</returns>
+        public static bool IsReadonly(this FieldDefinition fieldDefinition)
+        {
+            return !fieldDefinition.IsPublic || fieldDefinition.IsInitOnly || fieldDefinition.HasConstant;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
@@ -17,7 +17,7 @@ namespace NetArchTest.Rules.Extensions
         /// <returns>An indication of whether the field is readonly.</returns>
         public static bool IsReadonly(this FieldDefinition fieldDefinition)
         {
-            return !fieldDefinition.IsPublic || fieldDefinition.IsInitOnly || fieldDefinition.HasConstant;
+            return !fieldDefinition.IsPublic || fieldDefinition.IsInitOnly || fieldDefinition.HasConstant || fieldDefinition.IsCompilerControlled;
         }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
@@ -1,0 +1,23 @@
+namespace NetArchTest.Rules.Extensions
+{
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Mono.Cecil;
+
+    /// <summary>
+    /// Extensions for the <see cref="PropertyDefinition"/> class.
+    /// </summary>
+    static internal class PropertyDefinitionExtensions
+    {
+        /// <summary>
+        /// Tests whether a property is readonly
+        /// </summary>
+        /// <param name="propertyDefinition">The property to test.</param>
+        /// <returns>An indication of whether the property is readonly.</returns>
+        public static bool IsReadonly(this PropertyDefinition propertyDefinition)
+        {
+            return propertyDefinition.SetMethod == null || !propertyDefinition.SetMethod.IsPublic;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Collections.Generic;
     using Mono.Cecil;
+    using System.Reflection;
 
     /// <summary>
     /// Extensions for the <see cref="TypeDefinition"/> class.
@@ -53,6 +54,18 @@
             // Nested types have a forward slash that should be replaced with "+"
             var fullName = typeDefinition.FullName.Replace("/", "+");
             return Type.GetType(string.Concat(fullName, ", ", typeDefinition.Module.Assembly.FullName), true);
+        }
+
+        /// <summary>
+        /// Tests whether a class is immutable, i.e. all public fields are readonly and properties have no set method
+        /// </summary>
+        /// <param name="typeDefinition">The class to test.</param>
+        /// <returns>An indication of whether the type is immutable</returns>
+        public static bool IsImmutable(this TypeDefinition typeDefinition)
+        {
+            var propertiesAreReadonly = typeDefinition.Properties.All(p => p.IsReadonly());
+            var fieldsAreReadonly = typeDefinition.Fields.All(f => f.IsReadonly());
+            return propertiesAreReadonly && fieldsAreReadonly;
         }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Collections.Generic;
     using Mono.Cecil;
-    using System.Reflection;
 
     /// <summary>
     /// Extensions for the <see cref="TypeDefinition"/> class.

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -224,7 +224,14 @@
         /// <summary> Function for finding sealed classes. </summary>
         internal static FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
-            throw new NotImplementedException();
+            if (condition)
+            {
+                return input.Where(c => c.IsImmutable());
+            }
+            else
+            {
+                return input.Where(c => !c.IsImmutable());
+            }
         };
 
         /// <summary> Function for finding types in a particular namespace. </summary>

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -221,6 +221,12 @@
             }
         };
 
+        /// <summary> Function for finding sealed classes. </summary>
+        internal static FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        {
+            throw new NotImplementedException();
+        };
+
         /// <summary> Function for finding types in a particular namespace. </summary>
         internal static FunctionDelegate<string> ResideInNamespace = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
         {

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -407,6 +407,30 @@
             Adds an item to the list of dependencies that have been found.
             </summary>
         </member>
+        <member name="T:NetArchTest.Rules.Extensions.FieldDefinitionExtensions">
+            <summary>
+            Extensions for the <see cref="T:Mono.Cecil.FieldDefinition"/> class.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.FieldDefinitionExtensions.IsReadonly(Mono.Cecil.FieldDefinition)">
+            <summary>
+            Tests whether a field is readonly
+            </summary>
+            <param name="fieldDefinition">The field to test.</param>
+            <returns>An indication of whether the field is readonly.</returns>
+        </member>
+        <member name="T:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions">
+            <summary>
+            Extensions for the <see cref="T:Mono.Cecil.PropertyDefinition"/> class.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions.IsReadonly(Mono.Cecil.PropertyDefinition)">
+            <summary>
+            Tests whether a property is readonly
+            </summary>
+            <param name="propertyDefinition">The property to test.</param>
+            <returns>An indication of whether the property is readonly.</returns>
+        </member>
         <member name="T:NetArchTest.Rules.Extensions.TypeDefinitionExtensions">
             <summary>
             Extensions for the <see cref="T:Mono.Cecil.TypeDefinition"/> class.
@@ -433,6 +457,13 @@
             </summary>
             <param name="typeDefinition">The type definition to convert.</param>
             <returns>The equivalent <see cref="T:System.Type"/> object instance.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.IsImmutable(Mono.Cecil.TypeDefinition)">
+            <summary>
+            Tests whether a class is immutable, i.e. all public fields are readonly and properties have no set method
+            </summary>
+            <param name="typeDefinition">The class to test.</param>
+            <returns>An indication of whether the type is immutable</returns>
         </member>
         <member name="T:NetArchTest.Rules.Extensions.TypeExtensions">
             <summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -259,6 +259,18 @@
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.Conditions.BeImmutable">
+            <summary>
+            Selects types according that are immutable.
+            </summary>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.BeMutable">
+            <summary>
+            Selects types according that are mutable.
+            </summary>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
         <member name="M:NetArchTest.Rules.Conditions.ResideInNamespace(System.String)">
             <summary>
             Selects types that reside in a particular namespace.
@@ -485,6 +497,9 @@
             <summary> Function for finding public classes. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.BeSealed">
+            <summary> Function for finding sealed classes. </summary>
+        </member>
+        <member name="F:NetArchTest.Rules.FunctionDelegates.BeImmutable">
             <summary> Function for finding sealed classes. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.ResideInNamespace">
@@ -808,6 +823,18 @@
         <member name="M:NetArchTest.Rules.Predicates.AreNotSealed">
             <summary>
             Selects types according that are not marked as sealed.
+            </summary>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.AreImmutable">
+            <summary>
+            Selects types according that are immutable.
+            </summary>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.AreMutable">
+            <summary>
+            Selects types according that are mutable.
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -336,6 +336,26 @@
         }
 
         /// <summary>
+        /// Selects types according that are immutable.
+        /// </summary>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList AreImmutable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeImmutable, true, true);
+            return new PredicateList(_types, _sequence);
+        }
+
+        /// <summary>
+        /// Selects types according that are mutable.
+        /// </summary>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList AreMutable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeImmutable, true, false);
+            return new PredicateList(_types, _sequence);
+        }
+
+        /// <summary>
         /// Selects types that reside in a particular namespace.
         /// </summary>
         /// <param name="name">The namespace to match against.</param>

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -414,6 +414,36 @@
             Assert.True(result.IsSuccessful);
         }
 
+        [Fact(DisplayName = "Types can be selected for being immutable.")]
+        public void AreImmutable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Mutability")
+                .And()
+                .HaveName("ImmutableClass")
+                .Should()
+                .BeImmutable().GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected for being mutable.")]
+        public void AreMutable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Mutability")
+                .And()
+                .DoNotHaveName("ImmutableClass")
+                .Should()
+                .BeMutable().GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]
         public void ResideInNamespace_MatchesFound_ClassSelected()
         {
@@ -482,7 +512,7 @@
         }
 
         [Fact(DisplayName = "Types can be selected if they have a dependency on another type.")]
-        public void HaveDepencency_MatchesFound_ClassSelected()
+        public void HaveDependency_MatchesFound_ClassSelected()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
@@ -498,7 +528,7 @@
         }
 
         [Fact(DisplayName = "Types can be selected if they do not have a dependency on another type.")]
-        public void NotHaveDepencency_MatchesFound_ClassSelected()
+        public void NotHaveDependency_MatchesFound_ClassSelected()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -422,7 +422,7 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Mutability")
                 .And()
-                .HaveName("ImmutableClass")
+                .HaveNameStartingWith("ImmutableClass")
                 .Should()
                 .BeImmutable().GetResult();
 
@@ -437,7 +437,7 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Mutability")
                 .And()
-                .DoNotHaveName("ImmutableClass")
+                .DoNotHaveNameStartingWith("ImmutableClass")
                 .Should()
                 .BeMutable().GetResult();
 

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -19,6 +19,7 @@
     using NetArchTest.TestStructure.Nested;
     using NetArchTest.TestStructure.Scope;
     using NetArchTest.TestStructure.Sealed;
+    using NetArchTest.TestStructure.Mutability;
     using Xunit;
 
     public class PredicateTests
@@ -431,6 +432,36 @@
 
             Assert.Single(result); // One result
             Assert.Contains<Type>(typeof(NotSealedClass), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected for being immutable.")]
+        public void AreImmutable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Mutability")
+                .And()
+                .AreImmutable().GetTypes();
+
+            Assert.Single(result); // One result
+            Assert.Contains<Type>(typeof(ImmutableClass), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected for being mutable.")]
+        public void AreMutable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Mutability")
+                .And()
+                .AreMutable().GetTypes();
+
+            Assert.Equal(3, result.Count()); // Three types found
+            Assert.Contains<Type>(typeof(PartiallyMutableClass1), result);
+            Assert.Contains<Type>(typeof(PartiallyMutableClass2), result);
+            Assert.Contains<Type>(typeof(MutableClass), result);
         }
 
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -444,8 +444,10 @@
                 .And()
                 .AreImmutable().GetTypes();
 
-            Assert.Single(result); // One result
-            Assert.Contains<Type>(typeof(ImmutableClass), result);
+            Assert.Equal(3, result.Count()); // Three types found
+            Assert.Contains<Type>(typeof(ImmutableClass1), result);
+            Assert.Contains<Type>(typeof(ImmutableClass2), result);
+            Assert.Contains<Type>(typeof(ImmutableClass3), result);
         }
 
         [Fact(DisplayName = "Types can be selected for being mutable.")]

--- a/test/NetArchTest.TestStructure/Mutability/ImmutableClass.cs
+++ b/test/NetArchTest.TestStructure/Mutability/ImmutableClass.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has no mutable members.
+    /// </summary>
+    public class ImmutableClass
+    {
+        public object Property {get;}
+
+        public readonly object field;
+    }
+}

--- a/test/NetArchTest.TestStructure/Mutability/ImmutableClass1.cs
+++ b/test/NetArchTest.TestStructure/Mutability/ImmutableClass1.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has no mutable members.
+    /// </summary>
+    public class ImmutableClass1
+    {
+        public object GetOnlyProperty {get;}
+
+        public readonly object readonlyField;
+    }
+}

--- a/test/NetArchTest.TestStructure/Mutability/ImmutableClass2.cs
+++ b/test/NetArchTest.TestStructure/Mutability/ImmutableClass2.cs
@@ -3,10 +3,10 @@ namespace NetArchTest.TestStructure.Mutability
     /// <summary>
     /// An example class that has has no mutable members.
     /// </summary>
-    public class ImmutableClass
+    public class ImmutableClass2
     {
-        public object Property {get;}
+        public object PrivateSetProperty {get; private set;}
 
-        public readonly object field;
+        public const object constField = null;
     }
 }

--- a/test/NetArchTest.TestStructure/Mutability/ImmutableClass3.cs
+++ b/test/NetArchTest.TestStructure/Mutability/ImmutableClass3.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has no mutable members.
+    /// </summary>
+    public class ImmutableClass3
+    {
+        protected object Property {get; set;}
+
+        private object privateField;
+    }
+}

--- a/test/NetArchTest.TestStructure/Mutability/MutableClass.cs
+++ b/test/NetArchTest.TestStructure/Mutability/MutableClass.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has only mutable members.
+    /// </summary>
+    public class MutableClass
+    {
+        public object Property {get; set;}
+
+        public object field;
+    }
+}

--- a/test/NetArchTest.TestStructure/Mutability/PartiallyMutableClass1.cs
+++ b/test/NetArchTest.TestStructure/Mutability/PartiallyMutableClass1.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has some mutable members.
+    /// </summary>
+    public class PartiallyMutableClass1
+    {
+        public object Property {get;}
+
+        public object field;
+    }
+}

--- a/test/NetArchTest.TestStructure/Mutability/PartiallyMutableClass2.cs
+++ b/test/NetArchTest.TestStructure/Mutability/PartiallyMutableClass2.cs
@@ -1,0 +1,12 @@
+namespace NetArchTest.TestStructure.Mutability
+{
+    /// <summary>
+    /// An example class that has has some mutable members.
+    /// </summary>
+    public class PartiallyMutableClass2
+    {
+        public object Property {get; set;}
+
+        public readonly object field;
+    }
+}


### PR DESCRIPTION
This PR adds predicates and conditions to check mutability/immutability, where an immutable class is defined as one that has:
* no public properties with public set methods
* no public fields (excepting those that are readonly, const, or managed by the compiler)