### PR TITLE
Validate whether a class has only nullable fields

### DIFF
--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -335,7 +335,7 @@
         }
 
         /// <summary>
-        /// Selects types according that are immutable.
+        /// Selects types that are immutable.
         /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList BeImmutable()
@@ -345,7 +345,7 @@
         }
 
         /// <summary>
-        /// Selects types according that are mutable.
+        /// Selects types that are mutable.
         /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList BeMutable()
@@ -355,22 +355,22 @@
         }
 
         /// <summary>
-        /// Selects types according that are immutable.
+        /// Selects types according to whether they have nullable members.
         /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList BeNullable()
+        public ConditionList HaveOnlyNullableMembers()
         {
-            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, true);
+            _sequence.AddFunctionCall(FunctionDelegates.HasNullableMembers, true, true);
             return new ConditionList(_types, _should, _sequence);
         }
 
         /// <summary>
-        /// Selects types according that are mutable.
+        /// Selects types according to whether they have nullable members.
         /// </summary>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList BeNonNullable()
+        public ConditionList HaveSomeNonNullableMembers()
         {
-            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, false);
+            _sequence.AddFunctionCall(FunctionDelegates.HasNullableMembers, true, false);
             return new ConditionList(_types, _should, _sequence);
         }
 

--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -355,6 +355,26 @@
         }
 
         /// <summary>
+        /// Selects types according that are immutable.
+        /// </summary>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList BeNullable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, true);
+            return new ConditionList(_types, _should, _sequence);
+        }
+
+        /// <summary>
+        /// Selects types according that are mutable.
+        /// </summary>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList BeNonNullable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, false);
+            return new ConditionList(_types, _should, _sequence);
+        }
+
+        /// <summary>
         /// Selects types that reside in a particular namespace.
         /// </summary>
         /// <param name="name">The namespace to match against.</param>

--- a/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
@@ -27,7 +27,7 @@ namespace NetArchTest.Rules.Extensions
         /// <returns>An indication of whether the field is nullable.</returns>
         public static bool IsNullable(this FieldDefinition fieldDefinition)
         {
-            throw new NotImplementedException();
+            return fieldDefinition.FieldType.IsNullable();
         }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
@@ -19,5 +19,15 @@ namespace NetArchTest.Rules.Extensions
         {
             return !fieldDefinition.IsPublic || fieldDefinition.IsInitOnly || fieldDefinition.HasConstant || fieldDefinition.IsCompilerControlled;
         }
+        
+        /// <summary>
+        /// Tests whether a field is nullable
+        /// </summary>
+        /// <param name="fieldDefinition">The field to test.</param>
+        /// <returns>An indication of whether the field is nullable.</returns>
+        public static bool IsNullable(this FieldDefinition fieldDefinition)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
@@ -19,5 +19,15 @@ namespace NetArchTest.Rules.Extensions
         {
             return propertyDefinition.SetMethod == null || !propertyDefinition.SetMethod.IsPublic;
         }
+        
+        /// <summary>
+        /// Tests whether a property is nullable
+        /// </summary>
+        /// <param name="propertyDefinition">The property to test.</param>
+        /// <returns>An indication of whether the property is nullable.</returns>
+        public static bool IsNullable(this PropertyDefinition propertyDefinition)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
@@ -27,7 +27,7 @@ namespace NetArchTest.Rules.Extensions
         /// <returns>An indication of whether the property is nullable.</returns>
         public static bool IsNullable(this PropertyDefinition propertyDefinition)
         {
-            throw new NotImplementedException();
+            return propertyDefinition.PropertyType.IsNullable();
         }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -66,5 +66,17 @@
             var fieldsAreReadonly = typeDefinition.Fields.All(f => f.IsReadonly());
             return propertiesAreReadonly && fieldsAreReadonly;
         }
+
+        /// <summary>
+        /// Tests whether a class is nullable, i.e. no fields or properties are simple value types
+        /// </summary>
+        /// <param name="typeDefinition">The class to test.</param>
+        /// <returns>An indication of whether the type is nullable</returns>
+        public static bool IsNullable(this TypeDefinition typeDefinition)
+        {
+            var propertiesAreNullable = typeDefinition.Properties.All(p => p.IsNullable());
+            var fieldsAreNullable = typeDefinition.Fields.All(f => f.IsNullable());
+            return propertiesAreNullable && fieldsAreNullable;
+        }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -68,11 +68,11 @@
         }
 
         /// <summary>
-        /// Tests whether a class is nullable, i.e. no fields or properties are simple value types
+        /// Tests whether a Type has any memebers that are non-nullable value types
         /// </summary>
         /// <param name="typeDefinition">The class to test.</param>
-        /// <returns>An indication of whether the type is nullable</returns>
-        public static bool IsNullable(this TypeDefinition typeDefinition)
+        /// <returns>An indication of whether the type has any memebers that are non-nullable value types</returns>
+        public static bool HasNullableMembers(this TypeDefinition typeDefinition)
         {
             var propertiesAreNullable = typeDefinition.Properties.All(p => p.IsNullable());
             var fieldsAreNullable = typeDefinition.Fields.All(f => f.IsNullable());

--- a/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
@@ -1,0 +1,21 @@
+namespace NetArchTest.Rules.Extensions
+{
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Mono.Cecil;
+
+    static internal class TypeReferenceExtensions
+    {
+
+        /// <summary>
+        /// Tests whether a Type is a non-nullable value type
+        /// </summary>
+        /// <param name="typeReference">The class to test.</param>
+        /// <returns>An indication of whether the type has any memebers that are non-nullable value types</returns>
+        public static bool IsNullable(this TypeReference typeReference)
+        {
+            return !typeReference.IsValueType || typeReference.Resolve().ToType() == typeof(System.Nullable<>);
+        }
+    }
+}

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -235,15 +235,15 @@
         };
 
         /// <summary> Function for finding nullable classes. </summary>
-        internal static FunctionDelegate<bool> BeNullable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        internal static FunctionDelegate<bool> HasNullableMembers = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
             if (condition)
             {
-                return input.Where(c => c.IsNullable());
+                return input.Where(c => c.HasNullableMembers());
             }
             else
             {
-                return input.Where(c => !c.IsNullable());
+                return input.Where(c => !c.HasNullableMembers());
             }
         };
 

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -221,7 +221,7 @@
             }
         };
 
-        /// <summary> Function for finding sealed classes. </summary>
+        /// <summary> Function for finding immutable classes. </summary>
         internal static FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
             if (condition)
@@ -231,6 +231,19 @@
             else
             {
                 return input.Where(c => !c.IsImmutable());
+            }
+        };
+
+        /// <summary> Function for finding nullable classes. </summary>
+        internal static FunctionDelegate<bool> BeNullable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        {
+            if (condition)
+            {
+                return input.Where(c => c.IsNullable());
+            }
+            else
+            {
+                return input.Where(c => !c.IsNullable());
             }
         };
 

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -271,6 +271,18 @@
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.Conditions.BeNullable">
+            <summary>
+            Selects types according that are immutable.
+            </summary>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.BeNonNullable">
+            <summary>
+            Selects types according that are mutable.
+            </summary>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
         <member name="M:NetArchTest.Rules.Conditions.ResideInNamespace(System.String)">
             <summary>
             Selects types that reside in a particular namespace.
@@ -419,6 +431,13 @@
             <param name="fieldDefinition">The field to test.</param>
             <returns>An indication of whether the field is readonly.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.Extensions.FieldDefinitionExtensions.IsNullable(Mono.Cecil.FieldDefinition)">
+            <summary>
+            Tests whether a field is nullable
+            </summary>
+            <param name="fieldDefinition">The field to test.</param>
+            <returns>An indication of whether the field is readonly.</returns>
+        </member>
         <member name="T:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions">
             <summary>
             Extensions for the <see cref="T:Mono.Cecil.PropertyDefinition"/> class.
@@ -427,6 +446,13 @@
         <member name="M:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions.IsReadonly(Mono.Cecil.PropertyDefinition)">
             <summary>
             Tests whether a property is readonly
+            </summary>
+            <param name="propertyDefinition">The property to test.</param>
+            <returns>An indication of whether the property is readonly.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions.IsNullable(Mono.Cecil.PropertyDefinition)">
+            <summary>
+            Tests whether a property is nullable
             </summary>
             <param name="propertyDefinition">The property to test.</param>
             <returns>An indication of whether the property is readonly.</returns>
@@ -464,6 +490,13 @@
             </summary>
             <param name="typeDefinition">The class to test.</param>
             <returns>An indication of whether the type is immutable</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.IsNullable(Mono.Cecil.TypeDefinition)">
+            <summary>
+            Tests whether a class is nullable, i.e. no fields or properties are simple value types
+            </summary>
+            <param name="typeDefinition">The class to test.</param>
+            <returns>An indication of whether the type is nullable</returns>
         </member>
         <member name="T:NetArchTest.Rules.Extensions.TypeExtensions">
             <summary>
@@ -531,7 +564,10 @@
             <summary> Function for finding sealed classes. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.BeImmutable">
-            <summary> Function for finding sealed classes. </summary>
+            <summary> Function for finding immutable classes. </summary>
+        </member>
+        <member name="F:NetArchTest.Rules.FunctionDelegates.BeNullable">
+            <summary> Function for finding nullable classes. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.ResideInNamespace">
             <summary> Function for finding types in a particular namespace. </summary>
@@ -859,13 +895,25 @@
         </member>
         <member name="M:NetArchTest.Rules.Predicates.AreImmutable">
             <summary>
-            Selects types according that are immutable.
+            Selects types that are immutable.
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
         <member name="M:NetArchTest.Rules.Predicates.AreMutable">
             <summary>
-            Selects types according that are mutable.
+            Selects types that are mutable.
+            </summary>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.AreNullable">
+            <summary>
+            Selects types that have only nullable members.
+            </summary>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.AreNonNullable">
+            <summary>
+            Selects types that have some non-nullable members.
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -261,25 +261,25 @@
         </member>
         <member name="M:NetArchTest.Rules.Conditions.BeImmutable">
             <summary>
-            Selects types according that are immutable.
+            Selects types that are immutable.
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
         <member name="M:NetArchTest.Rules.Conditions.BeMutable">
             <summary>
-            Selects types according that are mutable.
+            Selects types that are mutable.
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.BeNullable">
+        <member name="M:NetArchTest.Rules.Conditions.HaveOnlyNullableMembers">
             <summary>
-            Selects types according that are immutable.
+            Selects types according to whether they have nullable members.
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.BeNonNullable">
+        <member name="M:NetArchTest.Rules.Conditions.HaveSomeNonNullableMembers">
             <summary>
-            Selects types according that are mutable.
+            Selects types according to whether they have nullable members.
             </summary>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
@@ -436,7 +436,7 @@
             Tests whether a field is nullable
             </summary>
             <param name="fieldDefinition">The field to test.</param>
-            <returns>An indication of whether the field is readonly.</returns>
+            <returns>An indication of whether the field is nullable.</returns>
         </member>
         <member name="T:NetArchTest.Rules.Extensions.PropertyDefinitionExtensions">
             <summary>
@@ -455,7 +455,7 @@
             Tests whether a property is nullable
             </summary>
             <param name="propertyDefinition">The property to test.</param>
-            <returns>An indication of whether the property is readonly.</returns>
+            <returns>An indication of whether the property is nullable.</returns>
         </member>
         <member name="T:NetArchTest.Rules.Extensions.TypeDefinitionExtensions">
             <summary>
@@ -491,12 +491,12 @@
             <param name="typeDefinition">The class to test.</param>
             <returns>An indication of whether the type is immutable</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.IsNullable(Mono.Cecil.TypeDefinition)">
+        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.HasNullableMembers(Mono.Cecil.TypeDefinition)">
             <summary>
-            Tests whether a class is nullable, i.e. no fields or properties are simple value types
+            Tests whether a Type has any memebers that are non-nullable value types
             </summary>
             <param name="typeDefinition">The class to test.</param>
-            <returns>An indication of whether the type is nullable</returns>
+            <returns>An indication of whether the type has any memebers that are non-nullable value types</returns>
         </member>
         <member name="T:NetArchTest.Rules.Extensions.TypeExtensions">
             <summary>
@@ -509,6 +509,20 @@
             </summary>
             <param name="type">The type to convert.</param>
             <returns>The converted value.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeExtensions.IsNullable(System.Type)">
+            <summary>
+            Tests whether a Type is a non-nullable value type
+            </summary>
+            <param name="type">The type to test.</param>
+            <returns>An indication of whether the type is a non-nullable value type</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeReferenceExtensions.IsNullable(Mono.Cecil.TypeReference)">
+            <summary>
+            Tests whether a Type is a non-nullable value type
+            </summary>
+            <param name="typeReference">The class to test.</param>
+            <returns>An indication of whether the type has any memebers that are non-nullable value types</returns>
         </member>
         <member name="T:NetArchTest.Rules.FunctionDelegates">
             <summary>
@@ -566,7 +580,7 @@
         <member name="F:NetArchTest.Rules.FunctionDelegates.BeImmutable">
             <summary> Function for finding immutable classes. </summary>
         </member>
-        <member name="F:NetArchTest.Rules.FunctionDelegates.BeNullable">
+        <member name="F:NetArchTest.Rules.FunctionDelegates.HasNullableMembers">
             <summary> Function for finding nullable classes. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.ResideInNamespace">
@@ -905,13 +919,13 @@
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.AreNullable">
+        <member name="M:NetArchTest.Rules.Predicates.HaveOnlyNullableMembers">
             <summary>
             Selects types that have only nullable members.
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.AreNonNullable">
+        <member name="M:NetArchTest.Rules.Predicates.HaveNonNullableMembers">
             <summary>
             Selects types that have some non-nullable members.
             </summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -510,13 +510,6 @@
             <param name="type">The type to convert.</param>
             <returns>The converted value.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Extensions.TypeExtensions.IsNullable(System.Type)">
-            <summary>
-            Tests whether a Type is a non-nullable value type
-            </summary>
-            <param name="type">The type to test.</param>
-            <returns>An indication of whether the type is a non-nullable value type</returns>
-        </member>
         <member name="M:NetArchTest.Rules.Extensions.TypeReferenceExtensions.IsNullable(Mono.Cecil.TypeReference)">
             <summary>
             Tests whether a Type is a non-nullable value type
@@ -925,7 +918,7 @@
             </summary>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.HaveNonNullableMembers">
+        <member name="M:NetArchTest.Rules.Predicates.HaveSomeNonNullableMembers">
             <summary>
             Selects types that have some non-nullable members.
             </summary>

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -336,7 +336,7 @@
         }
 
         /// <summary>
-        /// Selects types according that are immutable.
+        /// Selects types that are immutable.
         /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreImmutable()
@@ -346,12 +346,32 @@
         }
 
         /// <summary>
-        /// Selects types according that are mutable.
+        /// Selects types that are mutable.
         /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
         public PredicateList AreMutable()
         {
             _sequence.AddFunctionCall(FunctionDelegates.BeImmutable, true, false);
+            return new PredicateList(_types, _sequence);
+        }
+
+        /// <summary>
+        /// Selects types that have only nullable members.
+        /// </summary>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList AreNullable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, true);
+            return new PredicateList(_types, _sequence);
+        }
+
+        /// <summary>
+        /// Selects types that have some non-nullable members.
+        /// </summary>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList AreNonNullable()
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, false);
             return new PredicateList(_types, _sequence);
         }
 

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -359,9 +359,9 @@
         /// Selects types that have only nullable members.
         /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
-        public PredicateList AreNullable()
+        public PredicateList HaveOnlyNullableMembers()
         {
-            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, true);
+            _sequence.AddFunctionCall(FunctionDelegates.HasNullableMembers, true, true);
             return new PredicateList(_types, _sequence);
         }
 
@@ -369,9 +369,9 @@
         /// Selects types that have some non-nullable members.
         /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
-        public PredicateList AreNonNullable()
+        public PredicateList HaveNonNullableMembers()
         {
-            _sequence.AddFunctionCall(FunctionDelegates.BeNullable, true, false);
+            _sequence.AddFunctionCall(FunctionDelegates.HasNullableMembers, true, false);
             return new PredicateList(_types, _sequence);
         }
 

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -369,7 +369,7 @@
         /// Selects types that have some non-nullable members.
         /// </summary>
         /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
-        public PredicateList HaveNonNullableMembers()
+        public PredicateList HaveSomeNonNullableMembers()
         {
             _sequence.AddFunctionCall(FunctionDelegates.HasNullableMembers, true, false);
             return new PredicateList(_types, _sequence);

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -444,6 +444,36 @@
             Assert.True(result.IsSuccessful);
         }
 
+        [Fact(DisplayName = "Types can be selected for having only nullable memebers.")]
+        public void AreNullable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Nullable")
+                .And()
+                .DoNotHaveNameStartingWith("NonNullableClass")
+                .Should()
+                .BeNullable().GetResult();
+            
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected for having non-nullable memebers.")]
+        public void AreNonNullable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Nullable")
+                .And()
+                .DoNotHaveNameStartingWith("NullableClass")
+                .Should()
+                .BeNonNullable().GetResult();
+            
+            Assert.True(result.IsSuccessful);
+        }
+
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]
         public void ResideInNamespace_MatchesFound_ClassSelected()
         {

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -452,9 +452,11 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Nullable")
                 .And()
+                .AreNotNested() // ignore nested helper types
+                .And()
                 .DoNotHaveNameStartingWith("NonNullableClass")
                 .Should()
-                .BeNullable().GetResult();
+                .HaveOnlyNullableMembers().GetResult();
             
             Assert.True(result.IsSuccessful);
         }
@@ -467,9 +469,11 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Nullable")
                 .And()
+                .AreNotNested() // ignore nested helper types
+                .And()
                 .DoNotHaveNameStartingWith("NullableClass")
                 .Should()
-                .BeNonNullable().GetResult();
+                .HaveSomeNonNullableMembers().GetResult();
             
             Assert.True(result.IsSuccessful);
         }

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -475,7 +475,11 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Nullable")
                 .And()
-                .AreNullable().GetTypes();
+                .AreNotNested() // ignore nested helper types
+                .And()
+                .AreClasses()
+                .And()
+                .HaveOnlyNullableMembers().GetTypes();
 
             Assert.Single(result); // One result
             Assert.Contains<Type>(typeof(NullableClass), result);
@@ -489,11 +493,17 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Nullable")
                 .And()
-                .AreNonNullable().GetTypes();
+                .AreNotNested() // ignore nested helper types
+                .And()
+                .ArePublic()
+                .And()
+                .HaveNonNullableMembers().GetTypes();
 
-            Assert.Equal(2, result.Count()); // Three types found
+            Assert.Equal(4, result.Count()); // Four types found
             Assert.Contains<Type>(typeof(NonNullableClass1), result);
             Assert.Contains<Type>(typeof(NonNullableClass2), result);
+            Assert.Contains<Type>(typeof(NonNullableClass3), result);
+            Assert.Contains<Type>(typeof(NonNullableClass4), result);
         }
 
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -21,6 +21,7 @@
     using NetArchTest.TestStructure.Sealed;
     using NetArchTest.TestStructure.Mutability;
     using Xunit;
+    using NetArchTest.TestStructure.Nullable;
 
     public class PredicateTests
     {
@@ -464,6 +465,35 @@
             Assert.Contains<Type>(typeof(PartiallyMutableClass1), result);
             Assert.Contains<Type>(typeof(PartiallyMutableClass2), result);
             Assert.Contains<Type>(typeof(MutableClass), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected for having only nullable memebers.")]
+        public void AreNullable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Nullable")
+                .And()
+                .AreNullable().GetTypes();
+
+            Assert.Single(result); // One result
+            Assert.Contains<Type>(typeof(NullableClass), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected for having non-nullable memebers.")]
+        public void AreNonNullable_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Nullable")
+                .And()
+                .AreNonNullable().GetTypes();
+
+            Assert.Equal(2, result.Count()); // Three types found
+            Assert.Contains<Type>(typeof(NonNullableClass1), result);
+            Assert.Contains<Type>(typeof(NonNullableClass2), result);
         }
 
         [Fact(DisplayName = "Types can be selected if they reside in a namespace.")]

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -497,7 +497,7 @@
                 .And()
                 .ArePublic()
                 .And()
-                .HaveNonNullableMembers().GetTypes();
+                .HaveSomeNonNullableMembers().GetTypes();
 
             Assert.Equal(4, result.Count()); // Four types found
             Assert.Contains<Type>(typeof(NonNullableClass1), result);

--- a/test/NetArchTest.TestStructure/Nullable/NonNullableClass1.cs
+++ b/test/NetArchTest.TestStructure/Nullable/NonNullableClass1.cs
@@ -1,0 +1,11 @@
+namespace NetArchTest.TestStructure.Nullable {
+    
+    /// <summary>
+    /// An example class that has has non-nullable (i.e.null simple value typed) members.
+    /// </summary>
+    public class NonNullableClass1 {
+        public int _nonNullableIntField;
+
+        public int? NullableIntProperty {get; set;}
+    }
+}

--- a/test/NetArchTest.TestStructure/Nullable/NonNullableClass2.cs
+++ b/test/NetArchTest.TestStructure/Nullable/NonNullableClass2.cs
@@ -1,0 +1,11 @@
+namespace NetArchTest.TestStructure.Nullable {
+    
+    /// <summary>
+    /// An example class that has has non-nullable (i.e.null simple value typed) members.
+    /// </summary>
+    public class NonNullableClass2 {
+        public int? _nullableIntField;
+
+        public int NonNullableIntProperty {get; set;}
+    }
+}

--- a/test/NetArchTest.TestStructure/Nullable/NonNullableClass3.cs
+++ b/test/NetArchTest.TestStructure/Nullable/NonNullableClass3.cs
@@ -1,0 +1,15 @@
+namespace NetArchTest.TestStructure.Nullable {
+    
+    /// <summary>
+    /// An example class that has has non-nullable (i.e.null simple value typed) members.
+    /// </summary>
+    public class NonNullableClass3 {
+        public TestEnum EnumProperty {get; set;}
+
+        public enum TestEnum {
+            red, 
+            blue, 
+            green
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Nullable/NonNullableClass4.cs
+++ b/test/NetArchTest.TestStructure/Nullable/NonNullableClass4.cs
@@ -1,0 +1,13 @@
+namespace NetArchTest.TestStructure.Nullable {
+    
+    /// <summary>
+    /// An example class that has has non-nullable (i.e.null simple value typed) members.
+    /// </summary>
+    public class NonNullableClass4 {
+        public TestStruct StructProperty {get; set;}
+
+        public struct TestStruct {
+            int nonNullableStructField;
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Nullable/NullableClass.cs
+++ b/test/NetArchTest.TestStructure/Nullable/NullableClass.cs
@@ -1,0 +1,11 @@
+namespace NetArchTest.TestStructure.Nullable {
+    
+    /// <summary>
+    /// An example class that has has only nullable members.
+    /// </summary>
+    public class NullableClass {
+        public int? _nullableIntField;
+
+        public int? NullableIntProperty {get; set;}
+    }
+}


### PR DESCRIPTION
This PR adds the ability for validating that a class has only nullable fields - example use case is a DTO class that is deserialized from JSON. If the JSON has a null value for a field or property that is not nullable, deserialization will fail.

Also, some miscellaneous typos and copy/paste errors in comments are fixed.