### PR TITLE
Added the concept of a policy and rule for grouping and reporting on …

### DIFF
--- a/samples/NetArchTest.SampleRules/Program.cs
+++ b/samples/NetArchTest.SampleRules/Program.cs
@@ -3,70 +3,81 @@
     using NetArchTest.Rules;
     using NetArchTest.SampleLibrary.Data;
     using NetArchTest.SampleLibrary.Services;
+    using NetArchTest.Rules.Extensions;
+    using System;
 
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
-            //****************************************************
-            // Enforcing layered architecture
+            var architecturePolicy = Policy.Define("Passing Policy", "This policy demonstrated a valid passing policy with reasonable rules")
+                .For(Types.InCurrentDomain)
+                .Add(t =>
+                   t.That()
+                   .ResideInNamespace("NetArchTest.SampleLibrary.Presentation")
+                   .ShouldNot()
+                   .HaveDependencyOn("NetArchTest.SampleLibrary.Data")
+                   .GetResult()
+                   .MarkForRule("Enforcing layered architecture", "Controllers should not directly reference repositories")
+                )
+                .Add(t =>
+                    t.That().HaveDependencyOn("System.Data")
+                    .And().ResideInNamespace(("ArchTest"))
+                    .Should().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
+                    .GetResult()
+                    .MarkForRule("Controlling external dependencies", "Only classes in the data namespace can have a dependency on System.Data")
+                )
+                .Add(t =>
+                    t.That().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
+                    .And().AreClasses()
+                    .Should().ImplementInterface(typeof(IRepository<>))
+                    .GetResult()
+                    .MarkForRule("Miscellaneous application-specific rules", "All the classes in the data namespace should implement IRepository")
+                )
+                .Add(t =>
+                    t.That().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
+                    .And().AreClasses()
+                    .Should().HaveNameEndingWith("Repository")
+                    .GetResult()
+                    .MarkForRule("Miscellaneous application-specific rules", "Classes that implement IRepository should have the suffix 'Repository'")
+                )
+                .Add(t =>
+                    t.That().ImplementInterface(typeof(IRepository<>))
+                    .Should().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
+                    .GetResult()
+                    .MarkForRule("Miscellaneous application-specific rules", "Classes that implement IRepository must reside in the Data namespace")
+                )
+                .Add(t =>
+                    t.That().ImplementInterface(typeof(IWidgetService))
+                    .Should().BeSealed()
+                    .GetResult()
+                    .MarkForRule("Miscellaneous application-specific rules", "All the service classes should be sealed")
+                )
+                .Add(t =>
+                    t.That()
+                    .AreInterfaces()
+                    .Should()
+                    .HaveNameStartingWith("I")
+                    .GetResult()
+                    .MarkForRule("Generic implementation rules", "Interface names should start with an 'I'")
+                );
+            architecturePolicy.Evaluate();
 
-            // Controllers should not directly reference repositories
-            var result = Types.InCurrentDomain()
-                .That()
-                .ResideInNamespace("NetArchTest.SampleLibrary.Presentation")
-                .ShouldNot()
-                .HaveDependencyOn("NetArchTest.SampleLibrary.Data")
-                .GetResult().IsSuccessful;
+            architecturePolicy.Report(Console.Out);
 
-            //****************************************************
-            // Controlling external dependencies
+            var bogusPolicy = Policy.Define("Bogus Policy", "This policy demonstrates a failing policy")
+                .For(Types.InCurrentDomain)
+                .Add(t =>
+                    t.That()
+                    .AreInterfaces()
+                    .Should()
+                    .NotHaveNameStartingWith("I")
+                    .GetResult()
+                    .MarkForRule("Crazy rules", "Interfaces should not start with an 'I'")
+                );
+            bogusPolicy.Evaluate();
 
-            // Only classes in the data namespace can have a dependency on System.Data
-            result = Types.InCurrentDomain()
-                .That().HaveDependencyOn("System.Data")
-                .And().ResideInNamespace(("ArchTest"))
-                .Should().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
-                .GetResult().IsSuccessful;
-
-            //****************************************************
-            // Miscellaneous application-specific rules
-
-            // All the classes in the data namespace should implement IRepository
-            result = Types.InCurrentDomain()
-                .That().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
-                .And().AreClasses()
-                .Should().ImplementInterface(typeof(IRepository<>))
-                .GetResult().IsSuccessful;
-
-            // Classes that implement IRepository should have the suffix "Repository"
-            result = Types.InCurrentDomain()
-                .That().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
-                .And().AreClasses()
-                .Should().HaveNameEndingWith("Repository")
-                .GetResult().IsSuccessful;
-
-            // Classes that implement IRepository must reside in the Data namespace
-            result = Types.InCurrentDomain()
-                .That().ImplementInterface(typeof(IRepository<>))
-                .Should().ResideInNamespace(("NetArchTest.SampleLibrary.Data"))
-                .GetResult().IsSuccessful;
-
-            // All the service classes should be sealed
-            result = Types.InCurrentDomain()
-                .That().ImplementInterface(typeof(IWidgetService))
-                .Should().BeSealed()
-                .GetResult().IsSuccessful;
-
-            //****************************************************
-            // Generic implementation rules
-
-            // Interface names should start with an "I"
-            result = Types.InCurrentDomain()
-                .That().AreInterfaces()
-                .Should()
-                .HaveNameStartingWith("I")
-                .GetResult().IsSuccessful;
+            bogusPolicy.Report(Console.Out);
         }
     }
 }

--- a/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
@@ -7,7 +7,6 @@ namespace NetArchTest.Rules.Extensions
 
     static internal class TypeReferenceExtensions
     {
-
         /// <summary>
         /// Tests whether a Type is a non-nullable value type
         /// </summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -656,6 +656,11 @@
             <param name="typesLocator"><see cref="T:NetArchTest.Rules.Types"/>></param>
             <returns></returns>
         </member>
+        <member name="F:NetArchTest.Rules.Policy.TestResults">
+            <summary>
+            The results from the checks executed in the policy.
+            </summary>
+        </member>
         <member name="P:NetArchTest.Rules.Policy.Name">
             <summary>
             The simple name of the policy

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -639,6 +639,62 @@
             The Condition to apply to the call - i.e. "is" or "is not".
             </summary>
         </member>
+        <member name="T:NetArchTest.Rules.Policy">
+            <summary>
+            A simple aggregate of rules and results for overall reporting
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Policy.Description">
+            <summary>
+            A detailed description of the policy
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Policy.For(System.Func{NetArchTest.Rules.Types})">
+            <summary>
+            A lazy executed method to return the types for the evaluators
+            </summary>
+            <param name="typesLocator"><see cref="T:NetArchTest.Rules.Types"/>></param>
+            <returns></returns>
+        </member>
+        <member name="P:NetArchTest.Rules.Policy.Name">
+            <summary>
+            The simple name of the policy
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Policy.HasVoilations">
+            <summary>
+            Does the policy have any rule violations
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Policy.Define(System.String,System.String)">
+            <summary>
+            Defines a policy for use in the fluent syntax
+            </summary>
+            <param name="name"><see cref="P:NetArchTest.Rules.Policy.Name"/></param>
+            <param name="description"><see cref="P:NetArchTest.Rules.Policy.Description"/></param>
+            <returns></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Policy.Add(System.Func{NetArchTest.Rules.Types,NetArchTest.Rules.TestResult})">
+            <summary>
+            Adds a Func that evaluates to a <see cref="T:NetArchTest.Rules.TestResult"/>. Note: Be sure to use mark the TestResult with a Rule using <see cref="M:NetArchTest.Rules.TestResult.MarkForRule(System.String,System.String,System.Nullable{System.Int32})"/>
+            </summary>
+            <param name="testResult">A result of an evaulation</param>
+            <returns><see cref="T:NetArchTest.Rules.Policy"/> for use in Fluent syntax</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Policy.ReportAsync(System.IO.TextWriter)">
+            <summary>
+            Outputs a friendly display of the policy execution results;
+            </summary>
+            <param name="output"><see cref="T:System.IO.TextWriter"/> for outputs</param>
+            <returns><see cref="T:System.Threading.Tasks.Task"/></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Policy.Report(System.IO.TextWriter)">
+            <summary>
+            A synchronous variant of <see cref="M:NetArchTest.Rules.Policy.ReportAsync(System.IO.TextWriter)"/>
+            </summary>
+            <param name="output"></param>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:NetArchTest.Rules.Policy.Evaluate" -->
         <member name="T:NetArchTest.Rules.PredicateList">
             <summary>
             A set of predicates and types that have have conjunctions (i.e. "and", "or") and executors (i.e. Types(), TypeDefinitions()) applied to them.
@@ -966,6 +1022,26 @@
             <param name="dependency">The dependency type to match against.</param>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
+        <member name="T:NetArchTest.Rules.Rule">
+            <summary>
+            Defines a rule for reporting a Test result
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Rule.Name">
+            <summary>
+            The simple name of the rule
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Rule.Description">
+            <summary>
+            A more detailed description of the rule
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Rule.Id">
+            <summary>
+            An optional rule id to correlate with a master system for metrics and KPI's
+            </summary>
+        </member>
         <member name="T:NetArchTest.Rules.TestResult">
             <summary>
             Defines a result from a test carried out on a <see cref="T:NetArchTest.Rules.ConditionList"/>.
@@ -981,6 +1057,11 @@
             Collection populated with a list of types that failed the test, if the test was a failure.
             </summary>
         </member>
+        <member name="P:NetArchTest.Rules.TestResult.Rule">
+            <summary>
+            The Rule associated with this TestResult
+            </summary>
+        </member>
         <member name="M:NetArchTest.Rules.TestResult.Success">
             <summary>
             Creates a new instance of <see cref="T:NetArchTest.Rules.TestResult"/> indicating a successful test.
@@ -992,6 +1073,15 @@
             Creates a new instance of <see cref="T:NetArchTest.Rules.TestResult"/> indicating a failed test.
             </summary>
             <returns>Instance of <see cref="T:NetArchTest.Rules.TestResult"/></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.TestResult.MarkForRule(System.String,System.String,System.Nullable{System.Int32})">
+            <summary>
+            Assigns a <see cref="P:NetArchTest.Rules.TestResult.Rule"/> to this TestResult
+            </summary>
+            <param name="ruleName">The simple name of the rule <see cref="P:NetArchTest.Rules.Rule.Name"/></param>
+            <param name="ruleDescription">The detailed name of the rule <see cref="P:NetArchTest.Rules.Rule.Description"/></param>
+            <param name="ruleId">The optional Rule Id <see cref="P:NetArchTest.Rules.Rule.Id"/></param>
+            <returns></returns>
         </member>
         <member name="T:NetArchTest.Rules.Types">
             <summary>

--- a/src/NetArchTest.Rules/Policy.cs
+++ b/src/NetArchTest.Rules/Policy.cs
@@ -36,7 +36,11 @@ namespace NetArchTest.Rules
         }
 
         private List<Func<Types, TestResult>> TestResultFuncs = new List<Func<Types, TestResult>>();
-        private List<TestResult> TestResults = new List<TestResult>();
+
+        /// <summary>
+        /// The results from the checks executed in the policy.
+        /// </summary>
+        public List<TestResult> TestResults = new List<TestResult>();
 
         /// <summary>
         /// The simple name of the policy

--- a/src/NetArchTest.Rules/Policy.cs
+++ b/src/NetArchTest.Rules/Policy.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NetArchTest.Rules
+{
+    /// <summary>
+    /// A simple aggregate of rules and results for overall reporting
+    /// </summary>
+    public sealed class Policy
+    {
+        private Policy()
+        {
+        }
+
+        /// <summary>
+        /// A detailed description of the policy
+        /// </summary>
+        public string Description { get; private set; }
+
+        private Types _types;
+        private Func<Types> _typesLocator;
+        private bool _hasEvaluated;
+
+        /// <summary>
+        /// A lazy executed method to return the types for the evaluators
+        /// </summary>
+        /// <param name="typesLocator"><see cref="Types"/>></param>
+        /// <returns></returns>
+        public Policy For(Func<Types> typesLocator)
+        {
+            _typesLocator = typesLocator;
+            return this;
+        }
+
+        private List<Func<Types, TestResult>> TestResultFuncs = new List<Func<Types, TestResult>>();
+        private List<TestResult> TestResults = new List<TestResult>();
+
+        /// <summary>
+        /// The simple name of the policy
+        /// </summary>
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Does the policy have any rule violations
+        /// </summary>
+        public bool HasVoilations
+        {
+            get
+            {
+                if (!_hasEvaluated)
+                    Evaluate();
+                return TestResults.Any(r => !r.IsSuccessful);
+            }
+        }
+
+        /// <summary>
+        /// Defines a policy for use in the fluent syntax
+        /// </summary>
+        /// <param name="name"><see cref="Policy.Name"/></param>
+        /// <param name="description"><see cref="Policy.Description"/></param>
+        /// <returns></returns>
+        public static Policy Define(string name, string description)
+        {
+            return new Policy
+            {
+                Name = name,
+                Description = description
+            };
+        }
+
+        /// <summary>
+        /// Adds a Func that evaluates to a <see cref="TestResult"/>. Note: Be sure to use mark the TestResult with a Rule using <see cref="TestResult.MarkForRule(string, string, int?)"/>
+        /// </summary>
+        /// <param name="testResult">A result of an evaulation</param>
+        /// <returns><see cref="Policy"/> for use in Fluent syntax</returns>
+        public Policy Add(Func<Types, TestResult> testResult)
+        {
+            testResult.Invoke(Types.StubTypes());
+            if (_hasEvaluated)
+                throw new InvalidOperationException("This policy has already executed. Please only add rules before execution");
+            TestResultFuncs.Add(testResult);
+            return this;
+        }
+
+        /// <summary>
+        /// Outputs a friendly display of the policy execution results;
+        /// </summary>
+        /// <param name="output"><see cref="TextWriter"/> for outputs</param>
+        /// <returns><see cref="Task"/></returns>
+        public async Task ReportAsync(TextWriter output)
+        {
+            if (HasVoilations)
+            {
+                var violations = TestResults.Where(x => !x.IsSuccessful);
+                var aggregate = violations.GroupBy(x =>
+                $"{(x.Rule.Id.HasValue ? x.Rule.Id.Value.ToString() : x.Rule.Name)} - {x.Rule.Description}");
+
+                await output.WriteLineAsync($"---- Policy Results for Types {_types.Description}");
+
+                foreach (var r in aggregate)
+                {
+                    await output.WriteLineAsync($"\t Rule [{r.Key}] Voilations");
+                    foreach (var rule in r.Where(x => !x.IsSuccessful).SelectMany(x => x.FailingTypes).Distinct())
+                    {
+                        await output.WriteLineAsync($"\t\t [{rule}]");
+                    }
+                }
+                await output.WriteLineAsync("-----------------------------------------------------------");
+                await output.WriteLineAsync();
+                await output.WriteLineAsync();
+            }
+        }
+
+        /// <summary>
+        /// A synchronous variant of <see cref="ReportAsync(TextWriter)"/>
+        /// </summary>
+        /// <param name="output"></param>
+        public void Report(TextWriter output) => ReportAsync(output).GetAwaiter().GetResult();
+
+        /// <summary>
+        /// Evaluates all the rules added againsts the <see cref="Types" assigned/>
+        /// </summary>
+        public void Evaluate()
+        {
+            if (_hasEvaluated)
+                return;
+
+            if (_typesLocator == null)
+            {
+                throw new InvalidOperationException("You must call the .For() methods before executing to point to the types to evaluate");
+            }
+
+            _types = _typesLocator();
+            TestResults.AddRange(TestResultFuncs.Select(t => t(_types)));
+            _hasEvaluated = true;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Rule.cs
+++ b/src/NetArchTest.Rules/Rule.cs
@@ -1,0 +1,23 @@
+﻿namespace NetArchTest.Rules
+{
+    /// <summary>
+    /// Defines a rule for reporting a Test result
+    /// </summary>
+    public sealed class Rule
+    {
+        /// <summary>
+        /// The simple name of the rule
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A more detailed description of the rule
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// An optional rule id to correlate with a master system for metrics and KPI's
+        /// </summary>
+        public int? Id { get; set; }
+    }
+}

--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -23,6 +23,11 @@
         public IEnumerable<Type> FailingTypes { get; private set; }
 
         /// <summary>
+        /// The Rule associated with this TestResult
+        /// </summary>
+        internal Rule Rule { get; set; }
+
+        /// <summary>
         /// Creates a new instance of <see cref="TestResult"/> indicating a successful test.
         /// </summary>
         /// <returns>Instance of <see cref="TestResult"/></returns>
@@ -45,6 +50,24 @@
                 IsSuccessful = false,
                 FailingTypes = failingTypes
             };
+        }
+
+        /// <summary>
+        /// Assigns a <see cref="Rule"/> to this TestResult
+        /// </summary>
+        /// <param name="ruleName">The simple name of the rule <see cref="Rule.Name"/></param>
+        /// <param name="ruleDescription">The detailed name of the rule <see cref="Rule.Description"/></param>
+        /// <param name="ruleId">The optional Rule Id <see cref="Rule.Id"/></param>
+        /// <returns></returns>
+        public TestResult MarkForRule(string ruleName, string ruleDescription = "", int? ruleId = null)
+        {
+            Rule = new Rule
+            {
+                Name = ruleName,
+                Description = ruleDescription,
+                Id = ruleId
+            };
+            return this;
         }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/PolicyTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PolicyTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace NetArchTest.Rules.UnitTests
+{
+    public class PolicyTests
+    {
+        [Fact(DisplayName = "Policy can be executed more than once")]
+        public void Executed_Policy_Can_Be_Rerun()
+        {
+            var policy = Policy.Define("Unit Test Policy", "")
+                .Add(t => t.ShouldNot().HaveNameStartingWith("System").GetResult().MarkForRule("Exclude System Types"))
+                .For(Types.InCurrentDomain);
+
+            policy.Evaluate();
+
+            Assert.False(policy.HasVoilations);
+
+            policy.Evaluate();
+        }
+
+        [Fact(DisplayName = "Policy Must have a Func with Types defined")]
+        public void Executed_Policy_Requries_Types_Defined()
+        {
+            var policy = Policy.Define("Unit Test Policy", "")
+                .Add(t => t.ShouldNot().HaveNameStartingWith("System").GetResult().MarkForRule("Exclude System Types"))
+                ;
+
+            Assert.Throws<InvalidOperationException>(policy.Evaluate);
+        }
+    }
+}


### PR DESCRIPTION
This allows for a fluent way to group checks together into a Policy and marks the TestResults with a Rule that can have a name, description and optionally an ID. 
this can be used in the build pipeline to determine compliance to architecture guidelines 