### PR TITLE
Fixes #11.  Allows optional additional search directories to be appended to any call to Types.InAssembly

### DIFF
--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -1174,18 +1174,20 @@
             </summary>
             <returns>A list of types that can have predicates and conditions applied to it.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Types.InAssembly(System.Reflection.Assembly)">
+        <member name="M:NetArchTest.Rules.Types.InAssembly(System.Reflection.Assembly,System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Creates a list of types based on a particular assembly.
             </summary>
             <param name="assembly">The assembly to base the list on.</param>
+            <param name="searchDirectories">An optional list of search directories to allow resolution of referenced assemblies.</param>
             <returns>A list of types that can have predicates and conditions applied to it.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Types.InAssemblies(System.Collections.Generic.IEnumerable{System.Reflection.Assembly})">
+        <member name="M:NetArchTest.Rules.Types.InAssemblies(System.Collections.Generic.IEnumerable{System.Reflection.Assembly},System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Creates a list of types based on a list of assemblies.
             </summary>
             <param name="assemblies">The assemblies to base the list on.</param>
+            <param name="searchDirectories">An optional list of search directories to allow resolution of referenced assemblies.</param>
             <returns>A list of types that can have predicates and conditions applied to it.</returns>
         </member>
         <member name="M:NetArchTest.Rules.Types.InNamespace(System.String)">


### PR DESCRIPTION
If present, these are added to the ReadAssembly call via ReaderParameters to ensure any missing references can be picked up where possible, rather than relying on the directory in which the tests/assemblies are located.

I apologize that this is lacking tests, wanted to discuss the best way of adding them.  Generally I would use something like System.IO.Abstractions and provide an IFileSystem so that it can be completely mocked, creating assemblies as required for testing, similar to this: https://github.com/BenPhegan/ReferenceChecker/blob/master/ReferenceChecker.Tests/AssemblyReferenceGrapherTests.cs#L21 however I thought it would be worth discussion with you first.

Thoughts?