### PR TITLE
Fixed typo in Rules reporting: HasVoilations -> HasViolations

### DIFF
--- a/samples/NetArchTest.SampleRules/ExamplePolicies.cs
+++ b/samples/NetArchTest.SampleRules/ExamplePolicies.cs
@@ -82,7 +82,7 @@
         /// <returns><see cref="Task"/></returns>
         public static async Task ReportAsync(PolicyResults results, TextWriter output)
         {
-            if (results.HasVoilations)
+            if (results.HasViolations)
             {
                 await output.WriteLineAsync($"Policy violations found for: {results.Name}");
 

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -752,7 +752,7 @@
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Policies.PolicyResults"/> class.
             </summary>
         </member>
-        <member name="P:NetArchTest.Rules.Policies.PolicyResults.HasVoilations">
+        <member name="P:NetArchTest.Rules.Policies.PolicyResults.HasViolations">
             <summary>
             Gets whether or not the policy has any rule violations
             </summary>

--- a/src/NetArchTest.Rules/Policies/PolicyResults.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyResults.cs
@@ -21,7 +21,7 @@
         /// <summary>
         /// Gets whether or not the policy has any rule violations
         /// </summary>
-        public bool HasVoilations
+        public bool HasViolations
         {
             get
             {

--- a/test/NetArchTest.Rules.UnitTests/PolcyDefinitionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PolcyDefinitionTests.cs
@@ -35,7 +35,7 @@
 
             // Assert
             // This rule should fail and the result be available in the collection
-            Assert.True(result.HasVoilations);
+            Assert.True(result.HasViolations);
             Assert.False(result.Results.First().IsSuccessful);
             Assert.Single(result.Results.First().FailingTypes);
             Assert.Equal(typeof(ClassB2).FullName, result.Results.First().FailingTypes.First().FullName);
@@ -64,7 +64,7 @@
 
             // Assert
             // Both rules have been evaluated
-            Assert.False(result.HasVoilations);
+            Assert.False(result.HasViolations);
             Assert.True(result.Results.First().IsSuccessful);
             Assert.True(result.Results.Last().IsSuccessful);
         }
@@ -94,9 +94,9 @@
 
             // Assert
             // The policy has been evaluated to give different results
-            Assert.False(resultSucceed.HasVoilations);
+            Assert.False(resultSucceed.HasViolations);
             Assert.Single(resultSucceed.Results);
-            Assert.True(resultFail.HasVoilations);
+            Assert.True(resultFail.HasViolations);
             Assert.Equal(2, resultFail.Results.Count());
         }
 
@@ -136,7 +136,7 @@
             var result = policy.Evaluate();
 
             // Assert
-            Assert.False(result.HasVoilations);
+            Assert.False(result.HasViolations);
             Assert.Empty(result.Results);
         }
 


### PR DESCRIPTION
This fixes a typo in the rules results