### PR TITLE
- made dependency parameter aware of multiple types

### DIFF
--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -421,22 +421,22 @@
         /// <summary>
         /// Selects types that have a dependency on a particular type.
         /// </summary>
-        /// <param name="dependency">The dependency to match against.</param>
+        /// <param name="dependencies">The dependencies to match against.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList HaveDependencyOn(string dependency)
+        public ConditionList HaveDependencyOn(params string[] dependencies)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, true);
+            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, dependencies, true);
             return new ConditionList(_types, _should, _sequence);
         }
 
         /// <summary>
         /// Selects types that do not have a dependency on a particular type.
         /// </summary>
-        /// <param name="dependency">The dependency type to match against.</param>
+        /// <param name="dependencies">The dependency types to match against.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList NotHaveDependencyOn(string dependency)
+        public ConditionList NotHaveDependencyOn(params string[] dependencies)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, false);
+            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, dependencies, false);
             return new ConditionList(_types, _should, _sequence);
         }
     }

--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -421,22 +421,22 @@
         /// <summary>
         /// Selects types that have a dependency on a particular type.
         /// </summary>
-        /// <param name="dependencies">The dependencies to match against.</param>
+        /// <param name="dependency">The dependency to match against.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList HaveDependencyOn(params string[] dependencies)
+        public ConditionList HaveDependencyOn(string dependency)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, dependencies, true);
+            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, true);
             return new ConditionList(_types, _should, _sequence);
         }
 
         /// <summary>
         /// Selects types that do not have a dependency on a particular type.
         /// </summary>
-        /// <param name="dependencies">The dependency types to match against.</param>
+        /// <param name="dependency">The dependency type to match against.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList NotHaveDependencyOn(params string[] dependencies)
+        public ConditionList NotHaveDependencyOn(string dependency)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, dependencies, false);
+            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, false);
             return new ConditionList(_types, _should, _sequence);
         }
     }

--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -425,8 +425,27 @@
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList HaveDependencyOn(string dependency)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, true);
-            return new ConditionList(_types, _should, _sequence);
+            return HaveDependencyOn(dependency, true);
+        }
+
+        /// <summary>
+        /// Selects types that have a dependency on any of the particular types.
+        /// </summary>
+        /// <param name="dependencies">The dependencies to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList HaveDependencyOnAny(string[] dependencies)
+        {
+            return HaveDependencyOnMultiple(dependencies, c => c.Or(), true);
+        }
+
+        /// <summary>
+        /// Selects types that have a dependency on all of the particular types.
+        /// </summary>
+        /// <param name="dependencies">The dependencies to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList HaveDependencyOnAll(string[] dependencies)
+        {
+            return HaveDependencyOnMultiple(dependencies, c => c.And(), true);
         }
 
         /// <summary>
@@ -436,7 +455,47 @@
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
         public ConditionList NotHaveDependencyOn(string dependency)
         {
-            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, false);
+            return HaveDependencyOn(dependency, false);
+        }
+        /// <summary>
+        /// Selects types that do not have a dependency on any of the particular types.
+        /// </summary>
+        /// <param name="dependencies">The dependencies to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList NotHaveDependencyOnAny(string[] dependencies)
+        {
+            return HaveDependencyOnMultiple(dependencies, c => c.Or(), false);
+        }
+
+        /// <summary>
+        /// Selects types that do not have a dependency on all of the particular types.
+        /// </summary>
+        /// <param name="dependencies">The dependencies to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList NotHaveDependencyOnAll(string[] dependencies)
+        {
+            return HaveDependencyOnMultiple(dependencies, c => c.And(), false);
+        }
+
+        /// <summary>
+        /// Selects types that have a dependency on the particular types combined with the defined condition.
+        /// </summary>
+        private ConditionList HaveDependencyOnMultiple(string[] dependencies, Func<ConditionList, Conditions> conditionFunc, bool condition)
+        {
+            ConditionList conditionList = new ConditionList(_types, _should, _sequence);
+            foreach (string dependency in dependencies)
+            {
+                conditionList = conditionFunc(conditionList).HaveDependencyOn(dependency, condition);
+            }
+            return conditionList;
+        }
+
+        /// <summary>
+        /// Selects types that have a dependency on a particular type considering the condition.
+        /// </summary>
+        private ConditionList HaveDependencyOn(string dependency, bool condition)
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOn, new List<string> { dependency }, condition);
             return new ConditionList(_types, _should, _sequence);
         }
     }

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -318,12 +318,50 @@
             <param name="dependency">The dependency to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOnAny(System.String[])">
+            <summary>
+            Selects types that have a dependency on any of the particular types.
+            </summary>
+            <param name="dependencies">The dependencies to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOnAll(System.String[])">
+            <summary>
+            Selects types that have a dependency on all of the particular types.
+            </summary>
+            <param name="dependencies">The dependencies to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
         <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOn(System.String)">
             <summary>
             Selects types that do not have a dependency on a particular type.
             </summary>
             <param name="dependency">The dependency type to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOnAny(System.String[])">
+            <summary>
+            Selects types that do not have a dependency on any of the particular types.
+            </summary>
+            <param name="dependencies">The dependencies to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOnAll(System.String[])">
+            <summary>
+            Selects types that do not have a dependency on all of the particular types.
+            </summary>
+            <param name="dependencies">The dependencies to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOnMultiple(System.String[],System.Func{NetArchTest.Rules.ConditionList,NetArchTest.Rules.Conditions},System.Boolean)">
+            <summary>
+            Selects types that have a dependency on the particular types combined with the defined condition.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOn(System.String,System.Boolean)">
+            <summary>
+            Selects types that have a dependency on a particular type considering the condition.
+            </summary>
         </member>
         <member name="T:NetArchTest.Rules.Dependencies.DependencySearch">
             <summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -311,18 +311,18 @@
             <param name="pattern">The regular expression pattern to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOn(System.String[])">
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOn(System.String)">
             <summary>
             Selects types that have a dependency on a particular type.
             </summary>
-            <param name="dependencies">The dependencies to match against.</param>
+            <param name="dependency">The dependency to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOn(System.String[])">
+        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOn(System.String)">
             <summary>
             Selects types that do not have a dependency on a particular type.
             </summary>
-            <param name="dependencies">The dependency types to match against.</param>
+            <param name="dependency">The dependency type to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
         <member name="T:NetArchTest.Rules.Dependencies.DependencySearch">

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -311,18 +311,18 @@
             <param name="pattern">The regular expression pattern to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOn(System.String)">
+        <member name="M:NetArchTest.Rules.Conditions.HaveDependencyOn(System.String[])">
             <summary>
             Selects types that have a dependency on a particular type.
             </summary>
-            <param name="dependency">The dependency to match against.</param>
+            <param name="dependencies">The dependencies to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOn(System.String)">
+        <member name="M:NetArchTest.Rules.Conditions.NotHaveDependencyOn(System.String[])">
             <summary>
             Selects types that do not have a dependency on a particular type.
             </summary>
-            <param name="dependency">The dependency type to match against.</param>
+            <param name="dependencies">The dependency types to match against.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
         <member name="T:NetArchTest.Rules.Dependencies.DependencySearch">

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -250,7 +250,7 @@
         }
 
         [Fact(DisplayName = "Types can be selected if they are not classes.")]
-        public void AreNotClasses_MatchesFound_ClassesSelected ()
+        public void AreNotClasses_MatchesFound_ClassesSelected()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
@@ -310,7 +310,7 @@
         }
 
         [Fact(DisplayName = "Types can be selected if they are not interfaces.")]
-        public void AreNotInterfaces_MatchesFound_ClassesSelected ()
+        public void AreNotInterfaces_MatchesFound_ClassesSelected()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
@@ -370,7 +370,7 @@
         }
 
         [Fact(DisplayName = "Types can be selected for not being declared as public.")]
-        public void AreNotPublic_MatchesFound_ClassSelected ()
+        public void AreNotPublic_MatchesFound_ClassSelected()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
@@ -457,7 +457,7 @@
                 .DoNotHaveNameStartingWith("NonNullableClass")
                 .Should()
                 .OnlyHaveNullableMembers().GetResult();
-            
+
             Assert.True(result.IsSuccessful);
         }
 
@@ -474,7 +474,7 @@
                 .DoNotHaveNameStartingWith("NullableClass")
                 .Should()
                 .HaveSomeNonNullableMembers().GetResult();
-            
+
             Assert.True(result.IsSuccessful);
         }
 
@@ -561,6 +561,38 @@
             Assert.True(result.IsSuccessful);
         }
 
+        [Fact(DisplayName = "Types can be selected if they have a dependency on any other type.")]
+        public void HaveDependencyOnAny_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
+                .And()
+                .HaveNameStartingWith("HasDependency")
+                .Should()
+                .HaveDependencyOnAny(new[] { "NetArchTest.TestStructure.Dependencies.ExampleDependency" })
+                .GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they have a dependency on all another types.")]
+        public void HaveDependencyOnAll_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
+                .And()
+                .HaveNameStartingWith("HasDependency")
+                .Should()
+                .HaveDependencyOnAll(new[] { "NetArchTest.TestStructure.Dependencies.ExampleDependency", "NetArchTest.TestStructure.Dependencies.AnotherExampleDependency" })
+                .GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
         [Fact(DisplayName = "Types can be selected if they do not have a dependency on another type.")]
         public void NotHaveDependency_MatchesFound_ClassSelected()
         {
@@ -572,6 +604,38 @@
                 .HaveNameStartingWith("NoDependency")
                 .Should()
                 .NotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
+                .GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they do not have a dependency on any other type.")]
+        public void NotHaveDependencyOnAny_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
+                .And()
+                .HaveNameStartingWith("NoDependency")
+                .Should()
+                .NotHaveDependencyOnAny(new[] { "NetArchTest.TestStructure.Dependencies.ExampleDependency" })
+                .GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they do not have a dependency on all other types.")]
+        public void NotHaveDependencyOnAll_MatchesFound_ClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
+                .And()
+                .HaveNameStartingWith("NoDependency")
+                .Should()
+                .NotHaveDependencyOnAll(new[] { "NetArchTest.TestStructure.Dependencies.ExampleDependency", "NetArchTest.TestStructure.Dependencies.AnotherExampleDependency" })
                 .GetResult();
 
             Assert.True(result.IsSuccessful);

--- a/test/NetArchTest.TestStructure/Dependencies/AnotherExampleDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/AnotherExampleDependency.cs
@@ -1,0 +1,9 @@
+﻿namespace NetArchTest.TestStructure.Dependencies
+{
+    /// <summary>
+    /// An example class used in tests that identify dependencies.
+    /// </summary>
+    public class AnotherExampleDependency
+    {
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
@@ -3,5 +3,6 @@
     public class HasDependency
     {
         public ExampleDependency dependency { get; set; }
+        public AnotherExampleDependency anotherDependency { get; set; }
     }
 }


### PR DESCRIPTION
For some of our NetArchTests we would like to violate dependecies of multiple types in one rule. As the internal search engine already provide a list of dependencies, this change just enables this on client side. With the params keyword we do no need to change the signature in terms of creating 2 overloads.