### PR TITLE
Issue22 consistent dependency checks

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -223,8 +223,8 @@
                 {
                     if (instruction.Operand != null)
                     {
-                        var operand = instruction.Operand.ToString();
-                        var matches = results.SearchList.Where(m => operand.Contains(m)).ToArray();
+                        var operands = instruction.Operand.ToString().Split(new char[] { ' ', '<' });
+                        var matches = results.SearchList.Where(m => operands.Any(o => o.StartsWith(m))).ToArray();
                         foreach (var item in matches)
                         {
                             results.AddToFound(type, item);

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -555,7 +555,7 @@
                 .And()
                 .HaveNameStartingWith("HasDependency")
                 .Should()
-                .HaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
+                .HaveDependencyOn("NetArchTest.TestStructure.Dependencies.Examples.ExampleDependency")
                 .GetResult();
 
             Assert.True(result.IsSuccessful);
@@ -571,7 +571,7 @@
                 .And()
                 .HaveNameStartingWith("NoDependency")
                 .Should()
-                .NotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
+                .NotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.Examples.ExampleDependency")
                 .GetResult();
 
             Assert.True(result.IsSuccessful);

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
@@ -5,7 +5,7 @@
     using System.Linq;
     using System.Reflection;
     using NetArchTest.Rules.Dependencies;
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Search;
     using Xunit;
 
@@ -105,17 +105,21 @@
                 .That().HaveName(input.Name).GetTypeDefinitions();
 
             // Act
-            var result = search.FindTypesWithDependencies(subject, new List<string> { typeof(ExampleDependency).FullName });
+            var resultClass = search.FindTypesWithDependencies(subject, new List<string> { typeof(ExampleDependency).FullName });
+            var resultNamespace = search.FindTypesWithDependencies(subject, new List<string> { typeof(ExampleDependency).Namespace});
 
             // Assert
             if (expectToFind)
             {
-                Assert.Single(result); // Only one dependency found
-                Assert.Equal(result.First().FullName, result.First().FullName); // The correct dependency found
+                Assert.Single(resultClass); // Only one dependency found
+                Assert.Equal(resultClass.First().FullName, resultClass.First().FullName); // The correct dependency found
+                Assert.Single(resultNamespace); // Only one dependency found
+                Assert.Equal(resultNamespace.First().FullName, resultClass.First().FullName); // The correct dependency found
             }
             else
             {
-                Assert.Equal(0, result.Count); // No dependencies found
+                Assert.Equal(0, resultClass.Count); // No dependencies found
+                Assert.Equal(0, resultNamespace.Count); // No dependencies found
             }
         }
     }

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -592,7 +592,7 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
                 .And()
-                .HaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
+                .HaveDependencyOn("NetArchTest.TestStructure.Dependencies.Examples.ExampleDependency")
                 .GetTypes();
 
             Assert.Single(result); // Only one type found
@@ -607,7 +607,7 @@
                 .That()
                 .ResideInNamespace("NetArchTest.TestStructure.Dependencies.Implementation")
                 .And()
-                .DoNotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.ExampleDependency")
+                .DoNotHaveDependencyOn("NetArchTest.TestStructure.Dependencies.Examples.ExampleDependency")
                 .GetTypes();
 
             Assert.Single(result); // Only one type found

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependency.cs
@@ -1,4 +1,4 @@
-﻿namespace NetArchTest.TestStructure.Dependencies
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     /// <summary>
     /// An example class used in tests that identify dependencies.

--- a/test/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Implementation/HasDependency.cs
@@ -1,5 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Implementation
 {
+    using NetArchTest.TestStructure.Dependencies.Examples;
+
     public class HasDependency
     {
         public ExampleDependency dependency { get; set; }

--- a/test/NetArchTest.TestStructure/Dependencies/Search/AsyncMethod.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/AsyncMethod.cs
@@ -1,7 +1,7 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
     using System.Threading.Tasks;
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in an asynchronous method definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/GenericParameter.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/GenericParameter.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
     using System.Collections.Generic;
 
     /// <summary>

--- a/test/NetArchTest.TestStructure/Dependencies/Search/IndirectReference.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/IndirectReference.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes an indirect reference to a dependency in an different class.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/Inherited.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/Inherited.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that inherits from a dependency.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnType.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnType.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in the return type of a method.

--- a/test/NetArchTest.TestStructure/Dependencies/Search/NestedPrivateClass.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/NestedPrivateClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a nested private class.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PrivateConstructor.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PrivateConstructor.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public constructor definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PrivateField.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PrivateField.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private field definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PrivateMethod.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PrivateMethod.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private method definition.

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PrivateProperty.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PrivateProperty.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a private property definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PublicConstructor.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PublicConstructor.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public constructor definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PublicField.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PublicField.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public field definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PublicMethod.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PublicMethod.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public method definition.    

--- a/test/NetArchTest.TestStructure/Dependencies/Search/PublicProperty.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/PublicProperty.cs
@@ -1,6 +1,6 @@
 ﻿namespace NetArchTest.TestStructure.Dependencies.Search
 {
-    using NetArchTest.TestStructure.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
 
     /// <summary>
     /// Example class that includes a dependency in a public property definition.    


### PR DESCRIPTION
Fixes the problem identified with Issue #22, i.e. dependency searches were using `Contains()` for instructions and `StartsWith()` for every other type of match. This change ensures that searching will always be consistent so you can check for dependencies on namespaces as well as types.