### PR TITLE
add params keyword to fluent api method parameter

### DIFF
--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -474,7 +474,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList HaveDependencyOnAny(string[] dependencies)
+        public ConditionList HaveDependencyOnAny(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAny, dependencies, true);
             return new ConditionList(_types, _should, _sequence);
@@ -485,7 +485,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList HaveDependencyOnAll(string[] dependencies)
+        public ConditionList HaveDependencyOnAll(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAll, dependencies, true);
             return new ConditionList(_types, _should, _sequence);
@@ -506,7 +506,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList NotHaveDependencyOnAny(string[] dependencies)
+        public ConditionList NotHaveDependencyOnAny(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAny, dependencies, false);
             return new ConditionList(_types, _should, _sequence);
@@ -517,7 +517,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public ConditionList NotHaveDependencyOnAll(string[] dependencies)
+        public ConditionList NotHaveDependencyOnAll(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAll, dependencies, false);
             return new ConditionList(_types, _should, _sequence);

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -478,7 +478,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public PredicateList HaveDependencyOnAny(string[] dependencies)
+        public PredicateList HaveDependencyOnAny(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAny, dependencies, true);
             return new PredicateList(_types, _sequence);
@@ -489,7 +489,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public PredicateList HaveDependencyOnAll(string[] dependencies)
+        public PredicateList HaveDependencyOnAll(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAll, dependencies, true);
             return new PredicateList(_types, _sequence);
@@ -511,7 +511,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public PredicateList DoNotHaveDependencyOnAny(string[] dependencies)
+        public PredicateList DoNotHaveDependencyOnAny(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAny, dependencies, false);
             return new PredicateList(_types, _sequence);
@@ -522,7 +522,7 @@
         /// </summary>
         /// <param name="dependencies">The dependencies to match against. These can be namespaces or specific types.</param>
         /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
-        public PredicateList DoNotHaveDependencyOnAll(string[] dependencies)
+        public PredicateList DoNotHaveDependencyOnAll(params string[] dependencies)
         {
             _sequence.AddFunctionCall(FunctionDelegates.HaveDependencyOnAll, dependencies, false);
             return new PredicateList(_types, _sequence);


### PR DESCRIPTION
It would be nice to have a possibility to use method HaveDependencyOnAny() and others without the need of declaring an explicit array as in the first proposition in #19, I do not know why this didn't make to final implementation. 