### PR TITLE
Ignore all compiler generated nested classes

### DIFF
--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -258,8 +258,8 @@
 
                     foreach (var nested in type.NestedTypes)
                     {
-                        // Ignore compiler-generated async classes
-                        if (!nested.Interfaces.Any(i => i.InterfaceType.FullName.Equals(typeof(IAsyncStateMachine).FullName)))
+                        // Ignore all compiler-generated nested classes
+                        if (!nested.CustomAttributes.Any(x => x?.AttributeType?.FullName == typeof(CompilerGeneratedAttribute).FullName))
                         {
                             check.Enqueue(nested);
                         }


### PR DESCRIPTION
Right now only nested classes generated by the compiler to enable async/await are ignored, but the compiler generates many more nested classes (especially when ef core is involved) and all of them should be ignored in order to eliminate false-positive results.