### PR TITLE
Fix the TypeDefinition.GetType() to load managed C++ template instances.

### DIFF
--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -51,7 +51,12 @@
         public static Type ToType(this TypeDefinition typeDefinition)
         {
             // Nested types have a forward slash that should be replaced with "+"
-            var fullName = typeDefinition.FullName.Replace("/", "+");
+            // C++ template instantiations contain comma separator for template arguments,
+            // getting address operators and pointer type designations which should be prefixed by backslash
+            var fullName = typeDefinition.FullName.Replace("/", "+")
+                .Replace(",", "\\,")
+                .Replace("&", "\\&")
+                .Replace("*", "\\*");
             return Type.GetType(string.Concat(fullName, ", ", typeDefinition.Module.Assembly.FullName), true);
         }
 


### PR DESCRIPTION
Enhancement: special characters such as ',', '&' and '*' in a TypeDefinition.FullName, which originates from C++ template instance, should be prefixed with '\\' in order to be loaded per .Net Reflection.

Since a test case for the extension would include new project for managed C++ type and it'd make this project more heavy, testing part is skipped.