### PR TITLE
Exact match for dependency

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Mono.Cecil;
-  
+
     /// <summary>
     /// Finds dependencies within a given set of types.
     /// </summary>
@@ -112,12 +112,10 @@
             var baseClass = type.BaseType?.Resolve();
             if (baseClass != null)
             {
-                foreach (var dependency in results.SearchList)
+                foreach (var dependency in results.GetAllMatchingDependencies(baseClass.FullName))
                 {
-                    if (baseClass.FullName.StartsWith(dependency, StringComparison.InvariantCultureIgnoreCase))
-                    {
-                        results.AddToFound(type, dependency);
-                    }
+
+                    results.AddToFound(type, dependency);
                 }
             }
 
@@ -160,7 +158,7 @@
                 CheckGenericParameters(type, method.ReturnType.GenericParameters, ref results);
             }
 
-            if (results.SearchList.Any(m => method.ReturnType.FullName.StartsWith(m)))
+            if (results.GetAllMatchingDependencies(method.ReturnType.FullName).Any())
             {
                 results.AddToFound(type, method.ReturnType.FullName);
             }
@@ -191,7 +189,7 @@
                     }
 
                     // Check the property type
-                    if (results.SearchList.Any(m => property.PropertyType.FullName.StartsWith(m)))
+                    if (results.GetAllMatchingDependencies(property.PropertyType.FullName).Any())
                     {
                         results.AddToFound(type, property.PropertyType.FullName);
                     }
@@ -214,7 +212,7 @@
                         CheckGenericParameters(type, field.FieldType.GenericParameters, ref results);
                     }
 
-                    if (results.SearchList.Any(m => field.FieldType.FullName.StartsWith(m)))
+                    if (results.GetAllMatchingDependencies(field.FieldType.FullName).Any())
                     {
                         results.AddToFound(type, field.FieldType.FullName);
                     }
@@ -263,7 +261,7 @@
                             CheckGenericParameters(type, variable.VariableType.GenericParameters, ref results);
                         }
 
-                        if (results.SearchList.Any(m => variable.VariableType.FullName.StartsWith(m)))
+                        if (results.GetAllMatchingDependencies(variable.VariableType.FullName).Any())
                         {
                             results.AddToFound(type, variable.VariableType.FullName);
                         }
@@ -276,7 +274,7 @@
                     if (instruction.Operand != null)
                     {
                         var operands = instruction.Operand.ToString().Split(new char[] { ' ', '<' });
-                        var matches = results.SearchList.Where(m => operands.Any(o => o.StartsWith(m))).ToArray();
+                        var matches = results.GetAllDependenciesMatchingAnyOf(operands);
                         foreach (var item in matches)
                         {
                             results.AddToFound(type, item);
@@ -293,7 +291,7 @@
         {
             foreach (var generic in parameters)
             {
-                if (results.SearchList.Any(m => generic.FullName.StartsWith(m)))
+                if (results.GetAllMatchingDependencies(generic.FullName).Any())
                 {
                     results.AddToFound(type, generic.FullName);
                 }

--- a/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
+++ b/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
@@ -1,0 +1,191 @@
+﻿namespace NetArchTest.Rules.Dependencies
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    /// <summary>
+    /// Holds tree structure of full names; child nodes of each parent are indexed for optimal time of search.
+    /// </summary>
+    /// <example>
+    /// The sequence {"System.Linq", "System.Object", "System", "System.Collections.Generic", "NetArchTest.TestStructure.Dependencies.Examples"}
+    /// produces the tree
+    /// ""
+    /// |- "NetArchTest"
+    /// |  |- "TestStructure"
+    /// |     |- "Dependencies"
+    /// |        |- "Examples" (terminated)
+    /// |
+    /// |- "System" (terminated)
+    ///    |- "Collections"
+    ///    |  |- "Generic" (terminated)
+    ///    |
+    ///    |- "Linq" (terminated)
+    ///    |- "Object" (terminated)
+    /// </example>
+    /// <remarks>
+    /// In the example above the flag "terminated" means that marked name is presented in the sequence the tree is built for.
+    /// Despite of the fact that the namespace "System" takes over its descendants "Linq", "Object" and "Collections.Generic"
+    /// all of them are presented in the tree. For dependency search it provides the same results as original implementation
+    /// based on the String.StartsWith(...) does.
+    /// </remarks>
+    internal class NamespaceTree
+    {
+        /// <summary>
+        /// Represents a node in the namespace tree.
+        /// </summary>
+        private sealed class Node
+        {
+            /// <summary> Maps child namespace to its root node. </summary>
+            private Dictionary<string, Node> Nodes { get; } = new Dictionary<string, Node>();
+
+            /// <summary> Returs node's "terminated" flag. </summary>
+            public bool IsTerminated
+            {
+                get; private set;
+            }
+
+            /// <summary>
+            /// Adds new child node with given name or returns existing one.
+            /// </summary>
+            /// <param name="name">Name of child node.</param>
+            /// <returns>Child node with given name.</returns>
+            public Node GetOrAddNode(string name)
+            {
+                name = NormalizeString(name);
+
+                Node result;
+                if (!Nodes.TryGetValue(name, out result))
+                {
+                    result = new Node();
+                    Nodes.Add(name, result);
+                }
+                return result;
+            }
+
+            /// <summary>
+            /// Checks whether child node with given name exists and returns it.
+            /// </summary>
+            /// <param name="name">Name of child node of interest.</param>
+            /// <param name="node">Child node with given name, if it exists; otherwise, null.</param>
+            /// <returns>True, if child node with given name exists; otherwise, false.</returns>
+            public bool TryGetNode(string name, out Node node)
+            {
+                return Nodes.TryGetValue(NormalizeString(name), out node) && node != null;
+            }
+
+            /// <summary>
+            /// Terminates the node.
+            /// </summary>
+            public void Terminate()
+            {
+                IsTerminated = true;
+            }
+
+            private static string NormalizeString(string str)
+            {
+                return str.Normalize(NormalizationForm.FormC);
+            }
+        }
+
+        /// <summary> Holds the root for the namespace tree. </summary>
+        private readonly Node _root = new Node();
+
+        private static readonly char[] _namespaceSeparators = new char[] { '.', '<', '>', ':' };
+
+        /// <summary>
+        /// Initially fills the tree with given names.
+        /// </summary>
+        /// <param name="fullNames">Sequence of full names.</param>
+        public NamespaceTree(IEnumerable<string> fullNames)
+        {
+            foreach (string fullName in fullNames)
+            {
+                Add(fullName);
+            }
+        }
+
+        /// <summary>
+        /// Splits full name into subnamespaces and adds corresponding nodes to the tree.
+        /// </summary>
+        /// <param name="fullName">Can be empty, but not null.</param>
+        private void Add(string fullName)
+        {
+            if (fullName == null)
+            {
+                throw new ArgumentNullException(nameof(fullName));
+            }
+
+            var deepestNode = _root;
+
+            int subnameEndIndex = -1;
+            while (subnameEndIndex != fullName.Length)
+            {
+                int subnameStartIndex = subnameEndIndex + 1;
+                subnameEndIndex = GetSubnameEndIndex(fullName, subnameStartIndex);
+
+                deepestNode = deepestNode.GetOrAddNode(fullName.Substring(subnameStartIndex, subnameEndIndex - subnameStartIndex));
+            }
+
+            if (!deepestNode.IsTerminated)
+            {
+                deepestNode.Terminate();
+                TerminatedNodesCount++;
+            }
+        }
+
+        /// <summary> Count of terminated nodes in the tree. </summary>
+        public int TerminatedNodesCount { get; private set; } = 0;
+
+        /// <summary>
+        /// Retrieves the sequence of all matching names for given full name.
+        /// A name matches some full name, if its node is terminated and whole path from tree root to that node
+        /// builds the chain of namespaces in the full name.
+        /// </summary>
+        /// <param name="fullName">Full name to search matching names for.</param>
+        /// <returns>Sequence of all matching names.</returns>
+        /// <example>
+        /// If the tree contains "System.Collections" and "System.Collections.IList", both are returned
+        /// for the full name "System.Collections.IList".
+        /// </example>
+        public IEnumerable<string> GetAllMatchingNames(string fullName)
+        {
+            var builder = new StringBuilder();
+
+            var deepestNode = _root;
+
+            int subnameEndIndex = -1;
+            while (subnameEndIndex != fullName.Length)
+            {
+                int subnameStartIndex = subnameEndIndex + 1;
+                subnameEndIndex = GetSubnameEndIndex(fullName, subnameStartIndex);
+
+                string name = fullName.Substring(subnameStartIndex, subnameEndIndex - subnameStartIndex);
+                if (!deepestNode.TryGetNode(name, out deepestNode))
+                {
+                    yield break;
+                }
+
+                if (deepestNode.IsTerminated)
+                {
+                    builder.Append(name);
+                    yield return builder.ToString();
+
+                    builder.Append('.');
+                }
+            }
+        }
+
+        private static int GetSubnameEndIndex(string namespaceFullName, int subnameStartIndex)
+        {
+            int nextSeparatorIndex = namespaceFullName.IndexOfAny(_namespaceSeparators, subnameStartIndex);
+            if (nextSeparatorIndex < 0)
+            {
+                nextSeparatorIndex = namespaceFullName.Length;
+            }
+
+            return nextSeparatorIndex;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
+++ b/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2020 Siemens AG.
-// Licensed under the MIT License. See LICENSE file in the project root for details
-
-namespace NetArchTest.Rules.Dependencies
+﻿namespace NetArchTest.Rules.Dependencies
 {
     using System;
     using System.Collections.Generic;

--- a/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
+++ b/src/NetArchTest.Rules/Dependencies/NamespaceTree.cs
@@ -1,8 +1,10 @@
-﻿namespace NetArchTest.Rules.Dependencies
+﻿// Copyright (c) 2020 Siemens AG.
+// Licensed under the MIT License. See LICENSE file in the project root for details
+
+namespace NetArchTest.Rules.Dependencies
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
 
     /// <summary>

--- a/src/NetArchTest.Rules/Dependencies/SearchDefinition.cs
+++ b/src/NetArchTest.Rules/Dependencies/SearchDefinition.cs
@@ -15,6 +15,9 @@
         /// <summary> The list of types that has been checked by the search. </summary>
         private readonly HashSet<string> _checked;
 
+        /// <summary> The list of dependencies being searched for. </summary>
+        private readonly IEnumerable<string> _searchList;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SearchDefinition"/> class.
         /// </summary>
@@ -22,13 +25,28 @@
         {
             _found = new Dictionary<string, HashSet<string>>();
             _checked = new HashSet<string>();
-            SearchList = dependencies;
+            _searchList = dependencies;
         }
 
         /// <summary>
-        /// Gets the list of dependencies being searched for.
+        /// Returns all dependencies matching given type full name.
         /// </summary>
-        internal IEnumerable<string> SearchList { get; }
+        /// <param name="typeFullName"> Type full name for a dependency to match. </param>
+        /// <returns> Sequence of all dependencies matching given type full name or empty sequence, if there is no match. </returns>
+        internal IEnumerable<string> GetAllMatchingDependencies(string typeFullName)
+        {
+            return _searchList.Where(d => typeFullName.StartsWith(d));
+        }
+
+        /// <summary>
+        /// Returns all dependencies matching any of given type full names.
+        /// </summary>
+        /// <param name="typesFullNames"> Set of type full names for a dependency to match any of them. </param>
+        /// <returns> Sequence of all dependencies matching any of given type full names or empty sequence, if there is no match. </returns>
+        internal IEnumerable<string> GetAllDependenciesMatchingAnyOf(IEnumerable<string> typesFullNames)
+        {
+            return _searchList.Where(d => typesFullNames.Any(t => t.StartsWith(d)));
+        }
 
         /// <summary>
         /// Gets the list of dependency names that have been found.

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -433,6 +433,95 @@
             Finds matching dependencies for a set of generic parameters
             </summary>
         </member>
+        <member name="T:NetArchTest.Rules.Dependencies.NamespaceTree">
+            <summary>
+            Holds tree structure of full names; child nodes of each parent are indexed for optimal time of search.
+            </summary>
+            <example>
+            The sequence {"System.Linq", "System.Object", "System", "System.Collections.Generic", "NetArchTest.TestStructure.Dependencies.Examples"}
+            produces the tree
+            ""
+            |- "NetArchTest"
+            |  |- "TestStructure"
+            |     |- "Dependencies"
+            |        |- "Examples" (terminated)
+            |
+            |- "System" (terminated)
+               |- "Collections"
+               |  |- "Generic" (terminated)
+               |
+               |- "Linq" (terminated)
+               |- "Object" (terminated)
+            </example>
+            <remarks>
+            In the example above the flag "terminated" means that marked name is presented in the sequence the tree is built for.
+            Despite of the fact that the namespace "System" takes over its descendants "Linq", "Object" and "Collections.Generic"
+            all of them are presented in the tree. For dependency search it provides the same results as original implementation
+            based on the String.StartsWith(...) does.
+            </remarks>
+        </member>
+        <member name="T:NetArchTest.Rules.Dependencies.NamespaceTree.Node">
+            <summary>
+            Represents a node in the namespace tree.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Dependencies.NamespaceTree.Node.Nodes">
+            <summary> Maps child namespace to its root node. </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Dependencies.NamespaceTree.Node.IsTerminated">
+            <summary> Returs node's "terminated" flag. </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.Node.GetOrAddNode(System.String)">
+            <summary>
+            Adds new child node with given name or returns existing one.
+            </summary>
+            <param name="name">Name of child node.</param>
+            <returns>Child node with given name.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.Node.TryGetNode(System.String,NetArchTest.Rules.Dependencies.NamespaceTree.Node@)">
+            <summary>
+            Checks whether child node with given name exists and returns it.
+            </summary>
+            <param name="name">Name of child node of interest.</param>
+            <param name="node">Child node with given name, if it exists; otherwise, null.</param>
+            <returns>True, if child node with given name exists; otherwise, false.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.Node.Terminate">
+            <summary>
+            Terminates the node.
+            </summary>
+        </member>
+        <member name="F:NetArchTest.Rules.Dependencies.NamespaceTree._root">
+            <summary> Holds the root for the namespace tree. </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.#ctor(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+            Initially fills the tree with given names.
+            </summary>
+            <param name="fullNames">Sequence of full names.</param>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.Add(System.String)">
+            <summary>
+            Splits full name into subnamespaces and adds corresponding nodes to the tree.
+            </summary>
+            <param name="fullName">Can be empty, but not null.</param>
+        </member>
+        <member name="P:NetArchTest.Rules.Dependencies.NamespaceTree.TerminatedNodesCount">
+            <summary> Count of terminated nodes in the tree. </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.NamespaceTree.GetAllMatchingNames(System.String)">
+            <summary>
+            Retrieves the sequence of all matching names for given full name.
+            A name matches some full name, if its node is terminated and whole path from tree root to that node
+            builds the chain of namespaces in the full name.
+            </summary>
+            <param name="fullName">Full name to search matching names for.</param>
+            <returns>Sequence of all matching names.</returns>
+            <example>
+            If the tree contains "System.Collections" and "System.Collections.IList", both are returned
+            for the full name "System.Collections.IList".
+            </example>
+        </member>
         <member name="T:NetArchTest.Rules.Dependencies.SearchDefinition">
             <summary>
             Manages the parameters and results for a dependency search.
@@ -444,13 +533,16 @@
         <member name="F:NetArchTest.Rules.Dependencies.SearchDefinition._checked">
             <summary> The list of types that has been checked by the search. </summary>
         </member>
-        <member name="F:NetArchTest.Rules.Dependencies.SearchDefinition._searchList">
+        <member name="F:NetArchTest.Rules.Dependencies.SearchDefinition._searchTree">
             <summary> The list of dependencies being searched for. </summary>
         </member>
         <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.#ctor(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Dependencies.SearchDefinition"/> class.
             </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.Dependencies.SearchDefinition.UniqueDependenciesCount">
+            <summary> Count of unique dependencies in the set to search in. </summary>
         </member>
         <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.GetAllMatchingDependencies(System.String)">
             <summary>
@@ -475,6 +567,13 @@
             <summary>
             Gets the list of types that have dependencies.
             </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.GetDependenciesFoundForType(System.String)">
+            <summary>
+            Gets the list of dependencies found for given type.
+            </summary>
+            <param name="typeFullName">Full name of the type.</param>
+            <returns>The list of dependencies found for given type.</returns>
         </member>
         <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.IsChecked(Mono.Cecil.TypeDefinition)">
             <summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -444,15 +444,27 @@
         <member name="F:NetArchTest.Rules.Dependencies.SearchDefinition._checked">
             <summary> The list of types that has been checked by the search. </summary>
         </member>
+        <member name="F:NetArchTest.Rules.Dependencies.SearchDefinition._searchList">
+            <summary> The list of dependencies being searched for. </summary>
+        </member>
         <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.#ctor(System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Dependencies.SearchDefinition"/> class.
             </summary>
         </member>
-        <member name="P:NetArchTest.Rules.Dependencies.SearchDefinition.SearchList">
+        <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.GetAllMatchingDependencies(System.String)">
             <summary>
-            Gets the list of dependencies being searched for.
+            Returns all dependencies matching given type full name.
             </summary>
+            <param name="typeFullName"> Type full name for a dependency to match. </param>
+            <returns> Sequence of all dependencies matching given type full name or empty sequence, if there is no match. </returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Dependencies.SearchDefinition.GetAllDependenciesMatchingAnyOf(System.Collections.Generic.IEnumerable{System.String})">
+            <summary>
+            Returns all dependencies matching any of given type full names.
+            </summary>
+            <param name="typesFullNames"> Set of type full names for a dependency to match any of them. </param>
+            <returns> Sequence of all dependencies matching any of given type full names or empty sequence, if there is no match. </returns>
         </member>
         <member name="P:NetArchTest.Rules.Dependencies.SearchDefinition.DependenciesFound">
             <summary>

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
@@ -1,0 +1,368 @@
+﻿// January 9, 2020 Added DependencySearchScalabilityTests class
+
+namespace NetArchTest.Rules.UnitTests
+{
+    using Mono.Cecil;
+    using NetArchTest.Rules.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Examples;
+    using NetArchTest.TestStructure.Dependencies.Implementation;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// This test collection verifies that search methods take time which linearly depends
+    /// 1) on count of dependencies to search for (initial indexing of dependencies) and
+    /// 2) on total count of input type members,
+    /// i.e. dependecy search algorithm is scalable.
+    /// </summary>
+    /// <remarks>
+    /// Each search method is called twice and whole time is measured using the System.Diagnostics.StopWatch;
+    /// then average time of one call is calculated. Such an iteration is repeated several times in order to
+    /// collect the statistics which is processed at the end producing mean value and its margins
+    /// for 95% confidence interval.
+    /// 
+    /// Those measurements are done for input sets of three sizes: small, medium and large.
+    /// The results allow to calculate linearity factor k of the hypothesis t=k*n+c,
+    /// where n - size of input, t - the time ellapsed, c - some constant.
+    /// If two calculated mean values of k differ not more than the sum of their margins,
+    /// then the time is considered to depend linearly on the size of input set.
+    /// 
+    /// For more precise and more reliable measurenents and calculations without outliers
+    /// there could be used specialized frameworks like Benchmark.Net, however it could increase
+    /// test execution time from seconds to minutes.
+    /// </remarks>
+    [CollectionDefinition("Dependency Search Scalability", DisableParallelization = true)]
+    public class DependencySearchScalabilityTests
+    {
+        // Type definitions input sets of different size
+        private static IList<TypeDefinition> _inputTypesSmallSet;
+        private static IList<TypeDefinition> _inputTypesMediumSet;
+        private static IList<TypeDefinition> _inputTypesLargeSet;
+
+        // Total number of members of all types from input sets.
+        private static int _inputMembersSmallSetCount;
+        private static int _inputMembersMediumSetCount;
+        private static int _inputMembersLargeSetCount;
+
+        // Dependency sets of different size; each dependency is referenced by 
+        // at least one member of a type from input set
+        private static List<string> _dependenciesToSearchSmallSet;
+        private static List<string> _dependenciesToSearchMediumSet;
+        private static List<string> _dependenciesToSearchLargeSet;
+
+        // Additional items to sets of dependencies to search for; none of them is referenced,
+        // they only increase each corresponding set.
+        private static List<string> _nonDependenciesToSearchSmallSet;
+        private static List<string> _nonDependenciesToSearchMediumSet;
+        private static List<string> _nonDependenciesToSearchLargeSet;
+
+        private static string _implementationNamespace = typeof(HasDependency).Namespace;
+        private static string _dependencyNamespace = typeof(ExampleDependency).Namespace;
+
+        static DependencySearchScalabilityTests()
+        {
+            _dependenciesToSearchSmallSet = ConstructDependencyToSearchList(0x40, "ExampleDependency");     // 64 items
+            _dependenciesToSearchMediumSet = ConstructDependencyToSearchList(0x80, "ExampleDependency");    // 128 items
+            _dependenciesToSearchLargeSet = ConstructDependencyToSearchList(0x100, "ExampleDependency");    // 256 items
+
+            _nonDependenciesToSearchSmallSet = ConstructDependencyToSearchList(0x40, "NonDependency");      // 64 items
+            _nonDependenciesToSearchMediumSet = ConstructDependencyToSearchList(0x80, "NonDependency");     // 128 items
+            _nonDependenciesToSearchLargeSet = ConstructDependencyToSearchList(0x100, "NonDependency");     // 256 items
+
+            _inputTypesSmallSet = StubTypeDefinitionWithDependencies(0x80, _dependenciesToSearchSmallSet, out _inputMembersSmallSetCount);      // 128 types
+            _inputTypesMediumSet = StubTypeDefinitionWithDependencies(0x100, _dependenciesToSearchMediumSet, out _inputMembersMediumSetCount);  // 256 types
+            _inputTypesLargeSet = StubTypeDefinitionWithDependencies(0x200, _dependenciesToSearchLargeSet, out _inputMembersLargeSetCount);     // 512 types
+        }
+
+        [Fact(DisplayName = "Time to search all dependencies ~ O(n+m), n - total number of members in all input types; m - number of dependencies to search",
+              Timeout = 60000)]
+        public async void FindTypesWithAllDependencies_TimeGrowsLinearly()
+        {
+            // Arrange
+            var runner = new Runner(iterationCount: 9, repeatCount: 2);
+
+            // Warm up
+            await runner.Run(() => FindTypesWithAllDependencies(_inputTypesSmallSet, _dependenciesToSearchSmallSet));
+
+            // Act, measure the time spent on small set
+            var ellapsed0 = await runner.Run(() => FindTypesWithAllDependencies(_inputTypesSmallSet, _dependenciesToSearchSmallSet));
+
+            // Act, measure the time spent on medium set
+            var ellapsed1 = await runner.Run(() => FindTypesWithAllDependencies(_inputTypesMediumSet, _dependenciesToSearchMediumSet));
+
+            // Act, measure the time spent on large set
+            var ellapsed2 = await runner.Run(() => FindTypesWithAllDependencies(_inputTypesLargeSet, _dependenciesToSearchLargeSet));
+
+            double n0 = _inputMembersSmallSetCount + _dependenciesToSearchSmallSet.Count;
+            double n1 = _inputMembersMediumSetCount + _dependenciesToSearchMediumSet.Count;
+            double n2 = _inputMembersLargeSetCount + _dependenciesToSearchLargeSet.Count;
+
+            // Assert hypothesis: t(n)=k*n+c
+            // t0 = k*n0 + c |
+            // t1 = k*n1 + c | ==> k=(t1-t0)/(n1-n0)=?=(t2-t1)/(n2-n1)
+            // t2 = k*n2 + c |
+            double k1 = (ellapsed1.Mean - ellapsed0.Mean) / (n1 - n0);
+            double k2 = (ellapsed2.Mean - ellapsed1.Mean) / (n2 - n1);
+
+            double dk1 = (ellapsed1.Margins + ellapsed0.Margins) / (n1 - n0);
+            double dk2 = (ellapsed2.Margins + ellapsed1.Margins) / (n2 - n1);
+
+            // Assert that confidence intervals of both k values do overlap,
+            // i.e. both k values are considered to be equal.
+            // k1-dk1      k1+dk1
+            //   (.....k1    )
+            //            (.....k2    )
+            //          k2-dk2      k2+dk2
+            Assert.True(Math.Abs(k1 - k2) <= dk1 + dk2,
+                $"{k1}+-{dk1}; {k2}+-{dk2}\nSize; Ellapsed Ticks:\n{n0}; {ellapsed0.Mean}+-{ellapsed0.Margins}\n{n1}; {ellapsed1.Mean}+-{ellapsed1.Margins}\n{n2}; {ellapsed2.Mean}+-{ellapsed2.Margins}");
+        }
+
+
+        [Fact(DisplayName = "Time to search any dependency ~ O(n+m), n - total number of members in all input types; m - number of dependencies to search", 
+            Timeout = 60000)]
+        public async void FindTypesWithAnyDependencies_TimeGrowsLinearly()
+        {
+            // Arrange
+            var toSearchSmallSet = _nonDependenciesToSearchSmallSet.Concat(_dependenciesToSearchSmallSet);
+            var toSearchMediumSet = _nonDependenciesToSearchMediumSet.Concat(_dependenciesToSearchMediumSet);
+            var toSearchLargeSet = _nonDependenciesToSearchLargeSet.Concat(_dependenciesToSearchLargeSet);
+
+            var runner = new Runner(iterationCount: 9, repeatCount: 2);
+
+            // Warm up
+            await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesSmallSet, toSearchSmallSet));
+
+            // Act, measure the time spent on small set
+            var ellapsed0 = await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesSmallSet, toSearchSmallSet));
+
+            // Act, measure the time spent on medium set
+            var ellapsed1 = await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesMediumSet, toSearchMediumSet));
+
+            // Act, measure the time spent on large set
+            var ellapsed2 = await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesLargeSet, toSearchLargeSet));
+
+            // Assert hypothesis: t(n)=k*n+c
+            // t0 = k*n0 + c |
+            // t1 = k*n1 + c | ==> k=(t1-t0)/(n1-n0)=?=(t2-t1)/(n2-n1)
+            // t2 = k*n2 + c |
+
+            int n0 = _inputMembersSmallSetCount + _nonDependenciesToSearchSmallSet.Count + _dependenciesToSearchSmallSet.Count;
+            int n1 = _inputMembersMediumSetCount + _nonDependenciesToSearchMediumSet.Count + _dependenciesToSearchMediumSet.Count;
+            int n2 = _inputMembersLargeSetCount + _nonDependenciesToSearchLargeSet.Count + _dependenciesToSearchLargeSet.Count;
+
+            double k1 = (ellapsed1.Mean - ellapsed0.Mean) / (n1 - n0);
+            double k2 = (ellapsed2.Mean - ellapsed1.Mean) / (n2 - n1);
+
+            double dk1 = (ellapsed1.Margins + ellapsed0.Margins) / (n1 - n0);
+            double dk2 = (ellapsed2.Margins + ellapsed1.Margins) / (n2 - n1);
+
+            // Assert that confidence intervals of both k values do overlap,
+            // i.e. both k values are considered to be equal.
+            // k1-dk1      k1+dk1
+            //   (.....k1    )
+            //            (.....k2    )
+            //          k2-dk2      k2+dk2
+            Assert.True(Math.Abs(k1 - k2) <= dk1 + dk2,
+                $"{k1}+-{dk1}; {k2}+-{dk2}\nSize; Ellapsed Ticks:\n{n0}; {ellapsed0.Mean}+-{ellapsed0.Margins}\n{n1}; {ellapsed1.Mean}+-{ellapsed1.Margins}\n{n2}; {ellapsed2.Mean}+-{ellapsed2.Margins}");
+        }
+
+        private void FindTypesWithAnyDependencies(IEnumerable<TypeDefinition> inputTypes, IEnumerable<string> dependenciesToSearch)
+        {
+            var search = new DependencySearch();
+
+            // Act
+            var result = search.FindTypesWithAnyDependencies(inputTypes, dependenciesToSearch);
+
+            Assert.Equal(inputTypes.Count(), result.Count());
+        }
+
+        private void FindTypesWithAllDependencies(IEnumerable<TypeDefinition> inputTypes, IEnumerable<string> dependenciesToSearch)
+        {
+            // Arrange
+            var search = new DependencySearch();
+
+            // Act
+            var result = search.FindTypesWithAllDependencies(inputTypes, dependenciesToSearch);
+
+            // Assert
+            Assert.Equal(inputTypes.Count(), result.Count());
+        }
+
+        /// <summary>
+        /// Builds the list of type full names formed like "NetArchTest.TestStructure.Dependencies.Examples.<nameBase>0/nameBase>>"
+        /// </summary>
+        /// <param name="dependenciesCount">Number of full names to generate</param>
+        /// <param name="nameBase">Base part of the name to be extended with item's index like <nameBase>0, <nameBase>1,...<nameBase>n</param>
+        /// <returns>List of type full names.</returns>
+        static private List<string> ConstructDependencyToSearchList(int dependenciesCount, string nameBase)
+        {
+            return Enumerable.Range(0, dependenciesCount)
+                .Select(x => string.Concat(_dependencyNamespace, ".", nameBase, x.ToString(CultureInfo.InvariantCulture)))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Generates type definitions with properties; each property references one type from given list of dependencies,
+        /// so that every type references all types from that list.
+        /// </summary>
+        /// <param name="typesCount">Number of type definitions to generate</param>
+        /// <param name="dependenciesFullNames">List of dependencies for each type to reference</param>
+        /// <param name="totalCountOfMembers">Returns total number of members in all generated type definitions</param>
+        /// <returns>List of type definitions, each of them refers to all dependencies from given list</returns>
+        static private IList<TypeDefinition> StubTypeDefinitionWithDependencies(int typesCount, IReadOnlyCollection<string> dependenciesFullNames,
+            out int totalCountOfMembers)
+        {
+            var types = new List<TypeDefinition>(typesCount);
+
+            for (int i = typesCount; i-- != 0;)
+            {
+                var typeDefinition = new TypeDefinition(_implementationNamespace, string.Concat("InputType", i.ToString(CultureInfo.InvariantCulture)),
+                    TypeAttributes.UnicodeClass | TypeAttributes.Public);
+
+                int j = 0;
+                foreach (var fullName in dependenciesFullNames)
+                {
+                    int nameStart = fullName.LastIndexOf('.') + 1;
+                    string dependencyNamespace = nameStart != 0 ? fullName.Substring(0, nameStart - 1) : string.Empty;
+                    string dependencyName = fullName.Substring(nameStart);
+
+                    var dependency = new TypeDefinition(dependencyNamespace, dependencyName, TypeAttributes.Abstract);
+
+                    typeDefinition.Properties.Add(new PropertyDefinition(string.Concat("Property", j++.ToString(CultureInfo.InvariantCulture)),
+                        PropertyAttributes.None, dependency));
+                }
+
+                types.Add(typeDefinition);
+            }
+
+            totalCountOfMembers = typesCount * dependenciesFullNames.Count;
+            return types;
+        }
+
+        /// <summary>
+        /// Runner for single benchmark.
+        /// </summary>
+        private sealed class Runner
+        {
+            private readonly int _iterationCount;
+            private readonly int _repeatCount;
+
+            /// <summary>
+            /// Initializes the runner.
+            /// </summary>
+            /// <param name="iterationCount">Count of iterations to calculate mean value of ellapsed time and its margins</param>
+            /// <param name="repeatCount">Count of runs of a benchmark per each iteration to calculate average value of ellapsed time</param>
+            public Runner(int iterationCount = 16, int repeatCount = 5)
+            {
+                _iterationCount = iterationCount;
+                _repeatCount = repeatCount;
+            }
+
+            /// <summary>
+            /// Performs the benchmark several times and measures ellapsed time.
+            /// </summary>
+            /// <param name="action">Benchmark action method to perform</param>
+            /// <returns>Ellapsed time mean value and its margins for 95% confidence interval</returns>
+            public Task<Statistics.Value> Run(Action action)
+            {
+                return Task.Run(() => MeasureEllapsedTime(action));
+            }
+
+            private Statistics.Value MeasureEllapsedTime(Action action)
+            {
+                var ellapsed = new double[_iterationCount];
+
+                var threadOldPriority = System.Threading.Thread.CurrentThread.Priority;
+                System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.AboveNormal;
+
+                try
+                {
+                    for (int i = 0; i != _iterationCount; i++)
+                    {
+                        var stopwatch = new Stopwatch();
+                        stopwatch.Start();
+
+                        for (int j = _repeatCount; j-- != 0;)
+                        {
+                            action();
+                        }
+
+                        stopwatch.Stop();
+                        ellapsed[i] = stopwatch.ElapsedTicks / (double)_repeatCount;
+                    }
+                }
+                finally
+                {
+                    System.Threading.Thread.CurrentThread.Priority = threadOldPriority;
+                }
+
+                return Statistics.CalculateValue(ellapsed);
+            }
+        }
+
+        /// <summary>
+        /// Methods to process benchmark run results
+        /// </summary>
+        private static class Statistics
+        {
+            /// <summary>
+            /// Represents mean value together with its margins
+            /// </summary>
+            public struct Value
+            {
+                public double Mean
+                {
+                    get;
+                }
+                public double Margins
+                {
+                    get;
+                }
+
+                public Value(double mean, double margins)
+                {
+                    Mean = mean;
+                    Margins = margins;
+                }
+            }
+
+            /// <summary>
+            /// Calculates mean value and its margins for 95% confidence interval
+            /// </summary>
+            /// <param name="results">Results of several runs of the same benchmark</param>
+            /// <returns>Resulting mean value and its margins for 95% confidence interval</returns>
+            public static Value CalculateValue(IReadOnlyCollection<double> results)
+            {
+                if (results.Count < 2)
+                {
+                    throw new ArgumentException("There must be at least two results", nameof(results));
+                }
+
+                double mean = results.Average();
+                double deviation = Math.Sqrt(results.Select(x => (x - mean) * (x - mean)).Sum() / (results.Count - 1) / results.Count);
+
+                return new Value(mean: mean, margins: deviation * GetTinv95(results.Count));
+            }
+
+            // Student factors for the confidential probability 0.95 and different numbers of degrees of freedom.
+            private static double GetTinv95(int n)
+            {
+                return (n > 10 && n < 15) ? 2.2
+                    : (n >= 15 && n < 28) ? 2.1
+                    : n == 2 ? 12.7
+                    : n == 3 ? 4.3
+                    : n == 4 ? 3.2
+                    : n == 5 ? 2.8
+                    : n == 6 ? 2.6
+                    : (n == 7 || n == 8) ? 2.4
+                    : (n == 9 || n == 10) ? 2.3
+                    : 2.0;
+            }
+        }
+    }
+}

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
@@ -1,4 +1,5 @@
-﻿// January 9, 2020 Added DependencySearchScalabilityTests class
+﻿// Copyright (c) 2020 Siemens AG.
+// Licensed under the MIT License. See LICENSE file in the project root for details
 
 namespace NetArchTest.Rules.UnitTests
 {

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
@@ -87,7 +87,7 @@ namespace NetArchTest.Rules.UnitTests
             var runner = new Runner(iterationCount: 9, repeatCount: 2);
 
             // Warm up
-            await runner.Run(() => FindTypesWithAllDependencies(_inputTypesSmallSet, _dependenciesToSearchSmallSet));
+            await runner.Run(() => FindTypesWithAllDependencies(_inputTypesLargeSet, _dependenciesToSearchLargeSet));
 
             // Act, measure the time spent on small set
             var ellapsed0 = await runner.Run(() => FindTypesWithAllDependencies(_inputTypesSmallSet, _dependenciesToSearchSmallSet));
@@ -135,7 +135,7 @@ namespace NetArchTest.Rules.UnitTests
             var runner = new Runner(iterationCount: 9, repeatCount: 2);
 
             // Warm up
-            await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesSmallSet, toSearchSmallSet));
+            await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesLargeSet, toSearchLargeSet));
 
             // Act, measure the time spent on small set
             var ellapsed0 = await runner.Run(() => FindTypesWithAnyDependencies(_inputTypesSmallSet, toSearchSmallSet));

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchScalabilityTests.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2020 Siemens AG.
-// Licensed under the MIT License. See LICENSE file in the project root for details
-
-namespace NetArchTest.Rules.UnitTests
+﻿namespace NetArchTest.Rules.UnitTests
 {
     using Mono.Cecil;
     using NetArchTest.Rules.Dependencies;

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Reflection;
     using NetArchTest.Rules.Dependencies;
+    using NetArchTest.TestStructure.Dependencies.Example;
     using NetArchTest.TestStructure.Dependencies.Examples;
     using NetArchTest.TestStructure.Dependencies.Implementation;
     using NetArchTest.TestStructure.Dependencies.Search;
@@ -97,6 +98,68 @@
             this.RunDependencyTest(typeof(PublicProperty));
         }
 
+        [Theory(DisplayName = "Does not find a dependency that only partially matches actually referenced type.")]
+        [InlineData(typeof(AsyncMethod))]
+        [InlineData(typeof(GenericPrameter))]
+        [InlineData(typeof(IndirectReference))]
+        [InlineData(typeof(Inherited))]
+        [InlineData(typeof(MethodReturnType))]
+        [InlineData(typeof(NestedPrivateClass))]
+        [InlineData(typeof(PrivateConstructor))]
+        [InlineData(typeof(PrivateField))]
+        [InlineData(typeof(PrivateMethod))]
+        [InlineData(typeof(PrivateProperty))]
+        [InlineData(typeof(PublicConstructor))]
+        [InlineData(typeof(PublicField))]
+        [InlineData(typeof(PublicMethod))]
+        [InlineData(typeof(PublicProperty))]
+        public void DependencySearch_PartiallyMatchingDependency_NotFound(Type input)
+        {
+            this.RunDependencyTest(input, dependencyToSearch: typeof(ExampleDep),
+                                   expectToFindClass: false, expectToFindNamespace: input != typeof(IndirectReference));
+        }
+
+        [Theory(DisplayName = "Does not find a dependency from the namespace matching partially to the namespace of actually referenced type.")]
+        [InlineData(typeof(AsyncMethod))]
+        [InlineData(typeof(GenericPrameter))]
+        [InlineData(typeof(IndirectReference))]
+        [InlineData(typeof(Inherited))]
+        [InlineData(typeof(MethodReturnType))]
+        [InlineData(typeof(NestedPrivateClass))]
+        [InlineData(typeof(PrivateConstructor))]
+        [InlineData(typeof(PrivateField))]
+        [InlineData(typeof(PrivateMethod))]
+        [InlineData(typeof(PrivateProperty))]
+        [InlineData(typeof(PublicConstructor))]
+        [InlineData(typeof(PublicField))]
+        [InlineData(typeof(PublicMethod))]
+        [InlineData(typeof(PublicProperty))]
+        public void DependencySearch_PartiallyMatchingNamespace_NotFound(Type input)
+        {
+            this.RunDependencyTest(input, dependencyToSearch: typeof(ExampleDependencyInPartiallyMatchingNamespace),
+                                   expectToFindClass: false, expectToFindNamespace: false);
+        }
+
+        [Theory(DisplayName = "Does not find a dependency that differs only in case from actually referenced type.")]
+        [InlineData(typeof(AsyncMethod))]
+        [InlineData(typeof(GenericPrameter))]
+        [InlineData(typeof(Inherited))]
+        [InlineData(typeof(MethodReturnType))]
+        [InlineData(typeof(NestedPrivateClass))]
+        [InlineData(typeof(PrivateConstructor))]
+        [InlineData(typeof(PrivateField))]
+        [InlineData(typeof(PrivateMethod))]
+        [InlineData(typeof(PrivateProperty))]
+        [InlineData(typeof(PublicConstructor))]
+        [InlineData(typeof(PublicField))]
+        [InlineData(typeof(PublicMethod))]
+        [InlineData(typeof(PublicProperty))]
+        public void DependencySearch_DependencyWithDifferentCaseOfCharacters_NotFound(Type input)
+        {
+            this.RunDependencyTest(input, dependencyToSearch: typeof(ExampleDEPENDENCY),
+                                   expectToFindClass: false, expectToFindNamespace: true);
+        }
+
         [Fact(DisplayName = "A search for types with ANY dependencies returns types that have a dependency on at least one item in the list.")]
         public void FindTypesWithAnyDependencies_PublicProperty_Found()
         {
@@ -114,8 +177,8 @@
             // Assert
             Assert.Equal(3, result.Count); // Three types found
             Assert.Equal(typeof(HasDependencies).FullName, result.First().FullName); // Correct types returned...
-            Assert.Equal(typeof(HasAnotherDependency).FullName, result.Skip(1).First().FullName); 
-            Assert.Equal(typeof(HasDependency).FullName, result.Last().FullName); 
+            Assert.Equal(typeof(HasAnotherDependency).FullName, result.Skip(1).First().FullName);
+            Assert.Equal(typeof(HasDependency).FullName, result.Last().FullName);
         }
 
         [Fact(DisplayName = "A search for types with ALL dependencies returns types that have a dependency on all the items in the list.")]
@@ -144,6 +207,11 @@
         /// <param name="expectToFind"></param>
         private void RunDependencyTest(Type input, bool expectToFind = true)
         {
+            RunDependencyTest(input, typeof(ExampleDependency), expectToFind, expectToFind);
+        }
+
+        private void RunDependencyTest(Type input, Type dependencyToSearch, bool expectToFindClass, bool expectToFindNamespace)
+        {
             // Arrange
             var search = new DependencySearch();
             var subject = Types
@@ -152,20 +220,27 @@
 
             // Act
             // Search against the type name and its namespace - this demonstrates that namespace based searches also work
-            var resultClass = search.FindTypesWithAnyDependencies(subject, new List<string> { typeof(ExampleDependency).FullName });
-            var resultNamespace = search.FindTypesWithAnyDependencies(subject, new List<string> { typeof(ExampleDependency).Namespace});
+            var resultClass = search.FindTypesWithAnyDependencies(subject, new List<string> { dependencyToSearch.FullName });
+            var resultNamespace = search.FindTypesWithAnyDependencies(subject, new List<string> { dependencyToSearch.Namespace });
 
             // Assert
-            if (expectToFind)
+            if (expectToFindClass)
             {
                 Assert.Single(resultClass); // Only one dependency found
-                Assert.Equal(resultClass.First().FullName, resultClass.First().FullName); // The correct dependency found
-                Assert.Single(resultNamespace); // Only one dependency found
-                Assert.Equal(resultNamespace.First().FullName, resultClass.First().FullName); // The correct dependency found
+                Assert.Equal(input.FullName, resultClass.First().FullName); // The correct dependency found
             }
             else
             {
                 Assert.Equal(0, resultClass.Count); // No dependencies found
+            }
+
+            if (expectToFindNamespace)
+            {
+                Assert.Single(resultNamespace); // Only one dependency found
+                Assert.Equal(input.FullName, resultNamespace.First().FullName); // The correct dependency found
+            }
+            else
+            {
                 Assert.Equal(0, resultNamespace.Count); // No dependencies found
             }
         }

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
@@ -1,0 +1,10 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
+{
+    /// <summary>
+    /// An example class used in negative tests that identify dependencies.
+    /// Its name partially matches the 'ExampleDependency' which is actually referenced by test types.
+    /// </summary>
+    public class ExampleDep
+    {
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
@@ -1,4 +1,7 @@
-﻿namespace NetArchTest.TestStructure.Dependencies.Examples
+﻿// Copyright (c) 2020 Siemens AG.
+// Licensed under the MIT License. See LICENSE file in the project root for details
+
+namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     /// <summary>
     /// An example class used in negative tests that identify dependencies.

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDep.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2020 Siemens AG.
-// Licensed under the MIT License. See LICENSE file in the project root for details
-
-namespace NetArchTest.TestStructure.Dependencies.Examples
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     /// <summary>
     /// An example class used in negative tests that identify dependencies.

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
@@ -1,0 +1,10 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Example
+{
+    /// <summary>
+    /// An example class used in negative tests that identify dependencies.
+    /// Its namespace partially matches the 'Examples' containing 'ExampleDependency' which is actually referenced by test types.
+    /// </summary>
+    public class ExampleDependencyInPartiallyMatchingNamespace
+    {
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
@@ -1,4 +1,7 @@
-﻿namespace NetArchTest.TestStructure.Dependencies.Example
+﻿// Copyright (c) 2020 Siemens AG.
+// Licensed under the MIT License. See LICENSE file in the project root for details
+
+namespace NetArchTest.TestStructure.Dependencies.Example
 {
     /// <summary>
     /// An example class used in negative tests that identify dependencies.

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ExampleDependencyInPartiallyMatchingNamespace.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2020 Siemens AG.
-// Licensed under the MIT License. See LICENSE file in the project root for details
-
-namespace NetArchTest.TestStructure.Dependencies.Example
+﻿namespace NetArchTest.TestStructure.Dependencies.Example
 {
     /// <summary>
     /// An example class used in negative tests that identify dependencies.

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
@@ -1,0 +1,6 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
+{
+    public class ExampleDEPENDENCY
+    {
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
@@ -1,4 +1,7 @@
-﻿namespace NetArchTest.TestStructure.Dependencies.Examples
+﻿// Copyright (c) 2020 Siemens AG.
+// Licensed under the MIT License. See LICENSE file in the project root for details
+
+namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     public class ExampleDEPENDENCY
     {

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/IgnoreCaseExampleDependency.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2020 Siemens AG.
-// Licensed under the MIT License. See LICENSE file in the project root for details
-
-namespace NetArchTest.TestStructure.Dependencies.Examples
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     public class ExampleDEPENDENCY
     {


### PR DESCRIPTION
_Short description of the issue._

* False positive detection of a dependency found; here is an example:
    `var result = Types.InAssemblies(...)
                .ShouldNot().HaveDependencyOnAny(new[] {"Namespace.Rectangle"})
                .GetResult();`
    This predicate fails, if a type has dependency on the "Namespace.RectangleWithRoundCorners".
Similarly, types from the "NamespaceTwo" are reported as dependencies from the "Namespace".
* Current implementation of the DependencySearch class needs approx. 3 hours to scan 10000 source types against 12000 prohibited dependencies (yes, it was a sort of stress test for it).

_Short description of the fix suggested._

1. Right at the start full names of all dependencies are splitted into chains of names, e.g. `Namespace.Rectangle` from the example above produces the chain `Namespace`, `Rectangle`. That builds indexed tree of names.
2. Instead of trying the `string.StartsWith(...)` method on each referenced type, its full name is also splitted, e.g. `Namespace.RectangleWithRoundCorners` ==> `Namespace`, `RectangleWithRoundCorners`.
3. Each part is checked for presence in the indexed tree of names built at step 1. The result is positive only if there is terminated branch in the tree for the chain of names (see step 2).

_Test cases_

* Suggested fix does not break any existing test case, i.e. currently covered scenarios are not affected by the fix.
* There are test cases added which fail on false positive results of current implementation.
* There are two performance test added to demonstrate algorithmic time complexity is reduced to (almost) linear.

P.S.: should I create more detailed issue for the project?