### PR TITLE
fix potential collision when selecting types that inherit from type from another assembly

### DIFF
--- a/NetArchTest - all projects.sln
+++ b/NetArchTest - all projects.sln
@@ -19,6 +19,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetArchTest.SampleRules", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetArchTest.SampleLibrary", "samples\NetArchTest.SampleLibrary\NetArchTest.SampleLibrary.csproj", "{7123A8AE-678D-4D14-82E5-EB5607ABDC4A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetArchTest.CrossAssemblyTest.A", "test\NetArchTest.CrossAssemblyTest.A\NetArchTest.CrossAssemblyTest.A.csproj", "{70B787F2-8B79-4AA5-8C73-26682A605B6B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetArchTest.CrossAssemblyTest.B", "test\NetArchTest.CrossAssemblyTest.B\NetArchTest.CrossAssemblyTest.B.csproj", "{28692D43-3E08-43E4-BCBB-5940B9F741C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +49,14 @@ Global
 		{7123A8AE-678D-4D14-82E5-EB5607ABDC4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7123A8AE-678D-4D14-82E5-EB5607ABDC4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7123A8AE-678D-4D14-82E5-EB5607ABDC4A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70B787F2-8B79-4AA5-8C73-26682A605B6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70B787F2-8B79-4AA5-8C73-26682A605B6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70B787F2-8B79-4AA5-8C73-26682A605B6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70B787F2-8B79-4AA5-8C73-26682A605B6B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28692D43-3E08-43E4-BCBB-5940B9F741C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28692D43-3E08-43E4-BCBB-5940B9F741C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28692D43-3E08-43E4-BCBB-5940B9F741C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28692D43-3E08-43E4-BCBB-5940B9F741C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -55,6 +67,8 @@ Global
 		{D91C182D-DC97-4F9B-AFFE-8C7A62501DA6} = {660FEA1B-C886-4B72-AD70-1D7DD248CD76}
 		{4C5B170E-CAA1-421E-9FA5-9C2D6BEDB27C} = {460F2EC0-8774-4A26-835C-2FFFCAEEE1FA}
 		{7123A8AE-678D-4D14-82E5-EB5607ABDC4A} = {460F2EC0-8774-4A26-835C-2FFFCAEEE1FA}
+		{70B787F2-8B79-4AA5-8C73-26682A605B6B} = {660FEA1B-C886-4B72-AD70-1D7DD248CD76}
+		{28692D43-3E08-43E4-BCBB-5940B9F741C6} = {660FEA1B-C886-4B72-AD70-1D7DD248CD76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4388262D-A716-4918-A629-6072E4F8B668}

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -20,14 +20,34 @@
         {
             if (parent != null)
             {
-                return child.MetadataToken
-                    != parent.MetadataToken
-                    && child.EnumerateBaseClasses().Any(b => b.MetadataToken == parent.MetadataToken);
+                return !child.IsSameTypeAs(parent)
+                       && child.EnumerateBaseClasses().Any(b => b.IsSameTypeAs(parent));
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Tests whether two type definitions are from the same assembly.
+        /// The comparison is based on the full assembly names.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns>An indication of whether the both types are from the same assembly.</returns>
+        public static bool IsFromSameAssemblyAs(this TypeDefinition a, TypeDefinition b)
+        {
+            return a.Module.Assembly.ToString() == b.Module.Assembly.ToString();
+        }
+
+        /// <summary>
+        /// Tests whether the provided types are the same type.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns>An indication of whether the types are the same.</returns>
+        public static bool IsSameTypeAs(this TypeDefinition a, TypeDefinition b)
+        {
+            return a.IsFromSameAssemblyAs(b) && a.MetadataToken == b.MetadataToken;
         }
 
         /// <summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -683,6 +683,23 @@
             <param name="parent">The parent that is inherited.</param>
             <returns>An indication of whether the child inherits from the parent.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.IsFromSameAssemblyAs(Mono.Cecil.TypeDefinition,Mono.Cecil.TypeDefinition)">
+            <summary>
+            Tests whether two type definitions are from the same assembly.
+            The comparison is based on the full assembly names.
+            </summary>
+            <param name="a"></param>
+            <param name="b"></param>
+            <returns>An indication of whether the both types are from the same assembly.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.IsSameTypeAs(Mono.Cecil.TypeDefinition,Mono.Cecil.TypeDefinition)">
+            <summary>
+            Tests whether the provided types are the same type.
+            </summary>
+            <param name="a"></param>
+            <param name="b"></param>
+            <returns>An indication of whether the types are the same.</returns>
+        </member>
         <member name="M:NetArchTest.Rules.Extensions.TypeDefinitionExtensions.EnumerateBaseClasses(Mono.Cecil.TypeDefinition)">
             <summary>
             Enumerate the base classes throughout the chain of inheritence.

--- a/test/NetArchTest.CrossAssemblyTest.A/BaseClassFromA.cs
+++ b/test/NetArchTest.CrossAssemblyTest.A/BaseClassFromA.cs
@@ -1,0 +1,6 @@
+﻿namespace NetArchTest.CrossAssemblyTest.A
+{
+    public class BaseClassFromA
+    {
+    }
+}

--- a/test/NetArchTest.CrossAssemblyTest.A/NetArchTest.CrossAssemblyTest.A.csproj
+++ b/test/NetArchTest.CrossAssemblyTest.A/NetArchTest.CrossAssemblyTest.A.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+</Project>

--- a/test/NetArchTest.CrossAssemblyTest.B/AnotherDerivedClassFromB.cs
+++ b/test/NetArchTest.CrossAssemblyTest.B/AnotherDerivedClassFromB.cs
@@ -1,0 +1,8 @@
+using NetArchTest.CrossAssemblyTest.A;
+
+namespace NetArchTest.CrossAssemblyTest.B
+{
+    public class AnotherDerivedClassFromB : BaseClassFromA
+    {
+    }
+}

--- a/test/NetArchTest.CrossAssemblyTest.B/DerivedClassFromB.cs
+++ b/test/NetArchTest.CrossAssemblyTest.B/DerivedClassFromB.cs
@@ -1,0 +1,8 @@
+﻿using NetArchTest.CrossAssemblyTest.A;
+
+namespace NetArchTest.CrossAssemblyTest.B
+{
+    public class DerivedClassFromB : BaseClassFromA
+    {
+    }
+}

--- a/test/NetArchTest.CrossAssemblyTest.B/NetArchTest.CrossAssemblyTest.B.csproj
+++ b/test/NetArchTest.CrossAssemblyTest.B/NetArchTest.CrossAssemblyTest.B.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NetArchTest.CrossAssemblyTest.A\NetArchTest.CrossAssemblyTest.A.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/test/NetArchTest.Rules.UnitTests/NetArchTest.Rules.UnitTests.csproj
+++ b/test/NetArchTest.Rules.UnitTests/NetArchTest.Rules.UnitTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NetArchTest.Rules\NetArchTest.Rules.csproj" />
+    <ProjectReference Include="..\NetArchTest.CrossAssemblyTest.B\NetArchTest.CrossAssemblyTest.B.csproj" />
     <ProjectReference Include="..\NetArchTest.TestStructure\NetArchTest.TestStructure.csproj" />
   </ItemGroup>
 

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Linq;
     using System.Reflection;
+    using NetArchTest.CrossAssemblyTest.A;
+    using NetArchTest.CrossAssemblyTest.B;
     using NetArchTest.TestStructure.Abstract;
     using NetArchTest.TestStructure.Classes;
     using NetArchTest.TestStructure.CustomAttributes;
@@ -192,6 +194,20 @@
             Assert.Equal(2, result.Count()); // Two types found
             Assert.Contains<Type>(typeof(DerivedClass), result);
             Assert.Contains<Type>(typeof(DerivedDerivedClass), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they inherit from a type from a different assembly")]
+        public void Inherit_MatchesFound_ClassesSelected_AcrossAssemblies()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(DerivedClassFromB)))
+                .That()
+                .Inherit(typeof(BaseClassFromA))
+                .GetTypes();
+
+            Assert.Equal(2, result.Count());
+            Assert.Contains(typeof(DerivedClassFromB), result);
+            Assert.Contains(typeof(AnotherDerivedClassFromB), result);
         }
 
         [Fact(DisplayName = "Types can be selected if they do not inherit from a type.")]


### PR DESCRIPTION
Currently, there is a problem when selecting types that inherit from a type that is defined in different assembly than the assembly we are selecting from.

The problem lies here [TypeDefinitionExtensions.cs#L23](https://github.com/BenMorris/NetArchTest/blob/v1.2.5/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs#L23) as simple `MetadataToken` comparison is not reliable when types from multiple assemblies are present (type metadata token seems to be unique only in assembly context).

I've changed an implementation of `IsSubclassOf` in a way it is aware of type assembly and added a test case representing the problem.