### PR TITLE
Detect dependencies in generics

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -269,7 +269,7 @@
                 {
                     if (instruction.Operand != null)
                     {
-                        var operands = instruction.Operand.ToString().Split(new char[] { ' ', '<', ',', '>' });
+                        var operands = ExtractTypeNames(instruction.Operand.ToString());
                         var matches = results.GetAllDependenciesMatchingAnyOf(operands);
                         foreach (var item in matches)
                         {
@@ -298,12 +298,17 @@
         {
             foreach (var parameter in parameters)
             {
-                string fullName = parameter.ParameterType?.FullName ?? String.Empty;
-                if (results.GetAllMatchingDependencies(fullName).Any())
+                var typeNames = ExtractTypeNames(parameter.ParameterType.FullName);
+                if (results.GetAllDependenciesMatchingAnyOf(typeNames).Any())
                 {
-                    results.AddToFound(type, fullName);
+                    results.AddToFound(type, parameter.ParameterType.FullName);
                 }
             }
+        }
+
+        private IEnumerable<string> ExtractTypeNames(string fullName)
+        {
+            return fullName.Split(new char[] { ' ', '<', ',', '>' }).Where(x => !String.IsNullOrWhiteSpace(x));
         }
     }
 }

--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -283,13 +283,15 @@
         /// <summary>
         /// Finds matching dependencies for a set of generic parameters
         /// </summary>
-        private static void CheckGenericParameters(TypeDefinition type, IEnumerable<TypeReference> parameters, ref SearchDefinition results)
+        private void CheckGenericParameters(TypeDefinition type, IEnumerable<TypeReference> parameters, ref SearchDefinition results)
         {
             foreach (var generic in parameters)
             {
-                if (results.GetAllMatchingDependencies(generic.FullName).Any())
+                var types = ExtractTypeNames(generic.FullName);
+                var matches = results.GetAllDependenciesMatchingAnyOf(types);
+                foreach (var item in matches)
                 {
-                    results.AddToFound(type, generic.FullName);
+                    results.AddToFound(type, item);
                 }
             }
         }

--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -140,6 +140,15 @@
                 CheckGenericParameters(type, method.ReturnType.GenericParameters, ref results);
             }
 
+            if (method.ReturnType.IsGenericInstance)
+            {
+                var returnTypeAsGenericInstance = method.ReturnType as GenericInstanceType;
+                if (returnTypeAsGenericInstance.HasGenericArguments)
+                {
+                    CheckGenericParameters(type, returnTypeAsGenericInstance.GenericArguments, ref results);
+                }
+            }
+
             if (results.GetAllMatchingDependencies(method.ReturnType.FullName).Any())
             {
                 results.AddToFound(type, method.ReturnType.FullName);
@@ -274,7 +283,7 @@
         /// <summary>
         /// Finds matching dependencies for a set of generic parameters
         /// </summary>
-        private static void CheckGenericParameters(TypeDefinition type, IEnumerable<GenericParameter> parameters, ref SearchDefinition results)
+        private static void CheckGenericParameters(TypeDefinition type, IEnumerable<TypeReference> parameters, ref SearchDefinition results)
         {
             foreach (var generic in parameters)
             {

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
@@ -57,6 +57,12 @@
             this.RunDependencyTest(typeof(MethodReturnTypeGeneric));
         }
 
+        [Fact(DisplayName = "Finds a dependency in a public method's generic return type that contains another generic.")]
+        public void DependencySearch_MethodReturnTypeNestedGeneric_Found()
+        {
+            this.RunDependencyTest(typeof(MethodReturnTypeNestedGeneric));
+        }
+
         [Fact(DisplayName = "Finds a dependency in a public method's parameter.")]
         public void DependencySearch_MethodParameter_Found()
         {

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
@@ -51,6 +51,12 @@
             this.RunDependencyTest(typeof(MethodReturnType));
         }
 
+        [Fact(DisplayName = "Finds a dependency in a public method's generic return type.")]
+        public void DependencySearch_MethodReturnTypeGeneric_Found()
+        {
+            this.RunDependencyTest(typeof(MethodReturnTypeGeneric));
+        }
+
         [Fact(DisplayName = "Finds a dependency in a public method's parameter.")]
         public void DependencySearch_MethodParameter_Found()
         {

--- a/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearchTests.cs
@@ -62,6 +62,11 @@
         {
             this.RunDependencyTest(typeof(MethodParameter));
         }
+        [Fact(DisplayName = "Finds a dependency in a public method's generic parameter.")]
+        public void DependencySearch_MethodParameterGeneric_Found()
+        {
+            this.RunDependencyTest(typeof(MethodParameterGeneric));
+        }
 
         [Fact(DisplayName = "Finds a dependency in a nested private class.")]
         public void DependencySearch_NestedPrivateClass_Found()

--- a/test/NetArchTest.TestStructure/Dependencies/Search/MethodParameterGeneric.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/MethodParameterGeneric.cs
@@ -1,0 +1,16 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Search
+{
+    using System.Collections.Generic;
+    using NetArchTest.TestStructure.Dependencies.Examples;
+
+    /// <summary>
+    /// Example class that includes a dependency as a method parameter.
+    /// </summary>
+    public class MethodParameterGeneric
+    {
+        private void ExampleMethod(List<ExampleDependency> exampleDependency)
+        {
+
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnTypeGeneric.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnTypeGeneric.cs
@@ -1,0 +1,16 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Search
+{
+    using System.Threading.Tasks;
+    using NetArchTest.TestStructure.Dependencies.Examples;
+
+    /// <summary>
+    /// Example class that includes a dependency in the return type of a method.
+    /// </summary>
+    public class MethodReturnTypeGeneric
+    {
+        private Task<ExampleDependency> ExampleMethod()
+        {
+            return null;
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnTypeNestedGeneric.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/MethodReturnTypeNestedGeneric.cs
@@ -1,0 +1,17 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Search
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NetArchTest.TestStructure.Dependencies.Examples;
+
+    /// <summary>
+    /// Example class that includes a dependency in the return type of a method.
+    /// </summary>
+    public class MethodReturnTypeNestedGeneric
+    {
+        private Task<List<ExampleDependency>> ExampleMethod()
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This pull request solves three problems with not detecting dependencies in generics:

1) T\<Dependency\> Foo();  -- dependency in generic return type of method
2) T\<U\<Dependency\>\> Foo(); -- nested dependency in generics
3) void Foo(T\<Dependency\> foo); -- dependency in generic parameter of method



 problems 1 & 2 were reported in #57 