### PR TITLE
ResideInNamespaceContaining selects also nested types

### DIFF
--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -91,7 +91,7 @@
         {
             if ((typeDefinition.IsNestedPrivate) || (typeDefinition.IsNestedPublic))
             {
-                return typeDefinition.DeclaringType.Namespace;
+                return typeDefinition.DeclaringType.FullName;
             }
             return typeDefinition.Namespace;
         }

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -83,5 +83,17 @@
             var fieldsAreNullable = typeDefinition.Fields.All(f => f.IsNullable());
             return propertiesAreNullable && fieldsAreNullable;
         }
+
+        /// <summary>
+        /// Returns namespace of the given type, if the type is nested, namespace of containing type is returned instead
+        /// </summary>        
+        public static string GetNamespace(this TypeDefinition typeDefinition)
+        {
+            if ((typeDefinition.IsNestedPrivate) || (typeDefinition.IsNestedPublic))
+            {
+                return typeDefinition.DeclaringType.Namespace;
+            }
+            return typeDefinition.Namespace;
+        }
     }
 }

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -293,11 +293,11 @@
             Regex r = new Regex(pattern, RegexOptions.IgnoreCase);
             if (condition)
             {
-                return input.Where(c => r.Match(c.Namespace).Success);
+                return input.Where(c => r.Match(c.GetNamespace()).Success);
             }
             else
             {
-                return input.Where(c => !r.Match(c.Namespace).Success);
+                return input.Where(c => !r.Match(c.GetNamespace()).Success);
             }
         };
 

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -700,6 +700,19 @@
             Assert.Contains<Type>(typeof(ClassA1), result);
         }
 
+        [Fact(DisplayName = "Types (nested) can be selected if they reside in a namespace that contains a name part.")]
+        public void ResideInNamespaceContaining_NestedClassSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespaceContaining("Nested")
+                .GetTypes();
+
+            Assert.Equal(5, result.Count()); // Five types found
+            Assert.Contains<Type>(typeof(NestedPublic.NestedPublicClass), result);
+        }
+
         [Fact(DisplayName = "Types can be selected if they do not reside in a namespace that contains name part.")]
         public void DoNotResideInNamespaceContaiings_ClassSelected()
         {

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -709,7 +709,7 @@
                 .ResideInNamespaceContaining("Nested")
                 .GetTypes();
 
-            Assert.Equal(5, result.Count()); // Five types found
+            Assert.Equal(7, result.Count()); // Seven types found
             Assert.Contains<Type>(typeof(NestedPublic.NestedPublicClass), result);
         }
 


### PR DESCRIPTION
Fix for #53 
Nested types do not have namespace, thus namespace of containing type is used instead. 