### PR TITLE
New predicates : Are() and Have() and new conditions: Have() and Be()

### DIFF
--- a/src/NetArchTest.Rules/Conditions.cs
+++ b/src/NetArchTest.Rules/Conditions.cs
@@ -39,6 +39,29 @@
             _sequence = calls;
         }
 
+
+
+        /// <summary>
+        /// Selects types that fulfil user-defined custom predicate.
+        /// </summary>
+        /// <param name="predicate">The custom predicate to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList Have(Func<TypeDefinition, bool> predicate)
+        {
+            return Be(predicate);
+        }
+
+        /// <summary>
+        /// Selects types that fulfil user-defined custom predicate.
+        /// </summary>
+        /// <param name="predicate">The custom predicate to match against.</param>
+        /// <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        public ConditionList Be(Func<TypeDefinition, bool> predicate)
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.CustomUserPredicate, predicate, true);
+            return new ConditionList(_types, _should, _sequence);
+        }
+
         /// <summary>
         /// Selects types that have a specific name.
         /// </summary>

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -19,6 +19,21 @@
         /// <summary> The base delegate type used by every function. </summary>
         internal delegate IEnumerable<TypeDefinition> FunctionDelegate<T>(IEnumerable<TypeDefinition> input, T arg, bool condition);
 
+
+        /// <summary> Function for finding a specific type name. </summary>
+        internal static FunctionDelegate<Func<TypeDefinition, bool>> CustomUserPredicate = delegate (IEnumerable<TypeDefinition> input, Func<TypeDefinition, bool> predicate, bool condition)
+        {
+            if (condition)
+            {
+                return input.Where(predicate);
+            }
+            else
+            {
+                return input.Where(x => !predicate(x));
+            }
+        };
+
+
         /// <summary> Function for finding a specific type name. </summary>
         internal static FunctionDelegate<string> HaveName = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
         {

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -77,6 +77,20 @@
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Conditions"/> class.
             </summary>
         </member>
+        <member name="M:NetArchTest.Rules.Conditions.Have(System.Func{Mono.Cecil.TypeDefinition,System.Boolean})">
+            <summary>
+            Selects types that fulfil user-defined custom predicate.
+            </summary>
+            <param name="predicate">The custom predicate to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Conditions.Be(System.Func{Mono.Cecil.TypeDefinition,System.Boolean})">
+            <summary>
+            Selects types that fulfil user-defined custom predicate.
+            </summary>
+            <param name="predicate">The custom predicate to match against.</param>
+            <returns>An updated set of conditions that can be applied to a list of types.</returns>
+        </member>
         <member name="M:NetArchTest.Rules.Conditions.HaveName(System.String)">
             <summary>
             Selects types that have a specific name.
@@ -470,9 +484,9 @@
             Finds matching dependencies for a given method by scanning the code.
             </summary>
         </member>
-        <member name="M:NetArchTest.Rules.Dependencies.DependencySearch.CheckGenericParameters(Mono.Cecil.TypeDefinition,System.Collections.Generic.IEnumerable{Mono.Cecil.GenericParameter},NetArchTest.Rules.Dependencies.SearchDefinition@)">
+        <member name="M:NetArchTest.Rules.Dependencies.DependencySearch.CheckParameters(Mono.Cecil.TypeDefinition,System.Collections.Generic.IEnumerable{Mono.Cecil.TypeReference},NetArchTest.Rules.Dependencies.SearchDefinition@)">
             <summary>
-            Finds matching dependencies for a set of generic parameters
+            Finds matching dependencies for a set of generic or not parameters
             </summary>
         </member>
         <member name="T:NetArchTest.Rules.Dependencies.NamespaceTree">
@@ -740,6 +754,9 @@
         </member>
         <member name="T:NetArchTest.Rules.FunctionDelegates.FunctionDelegate`1">
             <summary> The base delegate type used by every function. </summary>
+        </member>
+        <member name="F:NetArchTest.Rules.FunctionDelegates.CustomUserPredicate">
+            <summary> Function for finding a specific type name. </summary>
         </member>
         <member name="F:NetArchTest.Rules.FunctionDelegates.HaveName">
             <summary> Function for finding a specific type name. </summary>
@@ -1091,6 +1108,20 @@
             <summary>
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Predicates"/> class.
             </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.Are(System.Func{Mono.Cecil.TypeDefinition,System.Boolean})">
+            <summary>
+            Selects types that fulfil user-defined custom predicate.
+            </summary>
+            <param name="predicate">The custom predicate to match against.</param>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Predicates.Have(System.Func{Mono.Cecil.TypeDefinition,System.Boolean})">
+            <summary>
+            Selects types that fulfil user-defined custom predicate.
+            </summary>
+            <param name="predicate">The custom predicate to match against.</param>
+            <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
         <member name="M:NetArchTest.Rules.Predicates.HaveName(System.String)">
             <summary>

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -35,6 +35,28 @@
             _sequence = calls;
         }
 
+
+        /// <summary>
+        /// Selects types that fulfil user-defined custom predicate.
+        /// </summary>
+        /// <param name="predicate">The custom predicate to match against.</param>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList Are(Func<TypeDefinition, bool> predicate)
+        {            
+            return Have(predicate);
+        }
+
+        /// <summary>
+        /// Selects types that fulfil user-defined custom predicate.
+        /// </summary>
+        /// <param name="predicate">The custom predicate to match against.</param>
+        /// <returns>An updated set of predicates that can be applied to a list of types.</returns>
+        public PredicateList Have(Func<TypeDefinition, bool> predicate)
+        {
+            _sequence.AddFunctionCall(FunctionDelegates.CustomUserPredicate, predicate, true);
+            return new PredicateList(_types, _sequence);
+        }
+
         /// <summary>
         /// Selects types that have a specific name.
         /// </summary>

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -14,6 +14,19 @@
 
     public class ConditionTests
     {
+        [Fact(DisplayName = "Types can be selected by user-defined custom predicate.")]
+        public void CustomPredicate_MatchFound_ClassesSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.NameMatching.Namespace2.Namespace3")
+                .Should()
+                .Have(x => x.Name == "ClassB2").GetResult();
+
+            Assert.True(result.IsSuccessful);
+        }
+
         [Fact(DisplayName = "Types can be selected by name.")]
         public void HaveName_MatchFound_ClassesSelected()
         {

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -26,7 +26,21 @@
 
     public class PredicateTests
     {
-        [Fact(DisplayName = "Types can be selected by name name.")]
+        [Fact(DisplayName = "Types can be selected by user-defined custom predicate.")]
+        public void CustomPredicate_MatchFound_ClassesSelected()
+        {
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .Have(x => x.Namespace.StartsWith("NetArchTest.TestStructure.NameMatching"))
+                .And()
+                .Have(x => x.Name == "ClassA1").GetTypes();
+
+            Assert.Single(result); // Only one type found
+            Assert.Equal<Type>(typeof(ClassA1), result.First()); // The correct type found
+        }
+
+        [Fact(DisplayName = "Types can be selected by name.")]
         public void HaveName_MatchFound_ClassesSelected()
         {
             var result = Types


### PR DESCRIPTION
Two new predicates : Are() and Have() and two new conditions : Have() and Be().
All of them accept `Func<TypeDefinition, bool> predicate` as argument which allows user to extend rules and define custom predicates and conditions.  

Requested in #54

