### PR TITLE
fix: consider types referenced by fields inside ctor base calls

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -220,6 +220,9 @@
                                 }
                             }
                             break;
+                        case FieldReference fieldReference:
+                            CheckTypeReference(fieldReference.DeclaringType);
+                            break;
                         case MethodReference methodReference:
                             CheckTypeReference( methodReference.DeclaringType);
                             break;

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -396,6 +396,12 @@
         public void DependencySearch_VariableTuple_NotFound()
         {
             Utils.RunDependencyTest(typeof(VariableTuple), typeof(Tuple<int, double>), false, true);
-        }        
+        }
+
+        [Fact(DisplayName = "Finds a dependency StaticType in BaseCtorCall.")]
+        public void DependencySearch_BaseCtorCall_Found()
+        {
+            Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
+        }
     }
 }

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+{
+    public struct Id
+    {
+    }
+
+    public static class StaticType
+    {
+        public static readonly Id SomeId;
+    }
+
+    public abstract class BaseCtorCallBase
+    {
+#pragma warning disable 219
+        protected BaseCtorCallBase(params Id[] ids)
+        {
+        }
+#pragma warning restore 219
+    }
+
+    public class BaseCtorCall : BaseCtorCallBase
+    {
+        public BaseCtorCall() :
+            base(StaticType.SomeId)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Static types refered by ctor base calls are not considered. In the following case the type **BaseCtorCall** has no dependency to **StaticType**, which in fact is wrong. Fixed by considering ``FieldReferences`` during Method visiting.
```cs
public struct Id { }

public static class StaticType
{
    public static readonly Id SomeId;
}

public abstract class BaseCtorCallBase
{
    protected BaseCtorCallBase(params Id[] ids)
    {
    }
}

public class BaseCtorCall : BaseCtorCallBase
{
    public BaseCtorCall() : base(StaticType.SomeId) { }
}
```