### PR TITLE
fix detecting global compiler-generated types in dependency search

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
@@ -86,7 +86,14 @@
             } 
             else
             {
-                _hasDependencyFromOutsideOfSearchTree = true;
+                if (_hasDependencyFromOutsideOfSearchTree == false)
+                {
+                    bool isGlobalAnonymousCompilerGeneratedType = String.IsNullOrEmpty(dependency.Namespace) && dependency.Name.StartsWith("<>");
+                    if (!isGlobalAnonymousCompilerGeneratedType)
+                    {
+                        _hasDependencyFromOutsideOfSearchTree = true;
+                    }
+                }
             }
         }
     }

--- a/test/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
@@ -2,12 +2,20 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
 
 #pragma warning disable 169
 
     public class Class_A
     {
+        public static void LetUsCreateSomeAnonymousTypes()
+        {
+            var numbers = Enumerable.Range(0, 1);
+            var result = from x in numbers
+                         join z in numbers on x equals z
+                         select (x, z);
+        }
     }
 
     public class Class_B  


### PR DESCRIPTION
I am not able to reproduce this problem on a smaller piece of code and write a test.
Compiler sometimes generates types that are located outside of any namespace, and these types should not be detected by dependency search.   