### PR TITLE
fix: analyze string const by comparing with full name

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -220,6 +220,9 @@
                                 }
                             }
                             break;
+                        case FieldReference fieldReference:
+                            CheckTypeReference(fieldReference.DeclaringType);
+                            break;
                         case MethodReference methodReference:
                             CheckTypeReference( methodReference.DeclaringType);
                             break;

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -96,6 +96,11 @@
                 {
                     CheckCustomAttributes(field);
                     CheckTypeReference(field.FieldType);
+                    if (field.HasConstant &&
+                        field.FieldType.FullName == typeof(string).FullName)
+                    {
+                        _result.CheckDependency(field.Constant.ToString());
+                    }
                 }
             }
         }
@@ -140,19 +145,19 @@
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodHeader(method);
+                    CheckMethodHeader(method);
                 }
 
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodBodyVariables(method);
+                    CheckMethodBodyVariables(method);
                 }
 
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodBodyInstructions(method);
+                    CheckMethodBodyInstructions(method);
                 }
             }
         }

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
@@ -74,6 +74,11 @@
             }           
         }
 
+        public void CheckDependency(string dependencyTypeFullName)
+        {
+            _foundDependencies.Add(dependencyTypeFullName);
+        }
+
         public void CheckDependency(TypeReference dependency)
         {
             var matchedDependencies = _searchTree.GetAllMatchingNames(dependency);

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -396,6 +396,12 @@
         public void DependencySearch_VariableTuple_NotFound()
         {
             Utils.RunDependencyTest(typeof(VariableTuple), typeof(Tuple<int, double>), false, true);
-        }        
+        }
+
+        [Fact(DisplayName = "Finds a dependency StaticType in BaseCtorCall.")]
+        public void DependencySearch_BaseCtorCall_Found()
+        {
+            Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
+        }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -403,5 +403,11 @@
         {
             Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
         }
+
+        [Fact(DisplayName = "Finds a dependency when a const string field accesses a type via full type name.")]
+        public void DependencySearch_ConstFieldString_Found()
+        {
+            Utils.RunDependencyTest(typeof(ConstStringFieldValue), typeof(Array), true, true);
+        }
     }
 }

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+{
+    public struct Id
+    {
+    }
+
+    public static class StaticType
+    {
+        public static readonly Id SomeId;
+    }
+
+    public abstract class BaseCtorCallBase
+    {
+#pragma warning disable 219
+        protected BaseCtorCallBase(params Id[] ids)
+        {
+        }
+#pragma warning restore 219
+    }
+
+    public class BaseCtorCall : BaseCtorCallBase
+    {
+        public BaseCtorCall() :
+            base(StaticType.SomeId)
+        {
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
@@ -1,0 +1,9 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+{
+    public class ConstStringFieldValue
+    {
+#pragma warning disable 219
+        private const string FullTypeName = "NetArchTest.TestStructure.Dependencies.Search.DependencyType.Array";
+#pragma warning restore 219
+    }
+}


### PR DESCRIPTION
The version <=1.2.6 has checked const string values. This is missing in the new dependency implementation and has been fixed by this commit. A test has also been added.