### PR TITLE
The one with slices

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -62,7 +62,7 @@
         /// <param name="input">The set of type definitions to search.</param>
         /// <param name="dependencies">The set of dependencies to look for.</param>
         /// <returns>A list of found types.</returns>
-        public IReadOnlyList<TypeDefinition> FindTypesThatOnlyOnlyHaveDependenciesOnAll(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
+        public IReadOnlyList<TypeDefinition> FindTypesThatOnlyHaveDependenciesOnAll(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {
             return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAll, dependencies);
         }

--- a/src/NetArchTest.Rules/NetArchTest.Rules.csproj
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="bm-nuget-icon.png" Pack="true" PackagePath=""  />
+    <None Include="bm-nuget-icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -625,7 +625,7 @@
             <param name="dependencies">The set of dependencies to look for.</param>
             <returns>A list of found types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Dependencies.DependencySearch.FindTypesThatOnlyOnlyHaveDependenciesOnAll(System.Collections.Generic.IEnumerable{Mono.Cecil.TypeDefinition},System.Collections.Generic.IEnumerable{System.String})">
+        <member name="M:NetArchTest.Rules.Dependencies.DependencySearch.FindTypesThatOnlyHaveDependenciesOnAll(System.Collections.Generic.IEnumerable{Mono.Cecil.TypeDefinition},System.Collections.Generic.IEnumerable{System.String})">
             <summary>
             Finds types that have a dependency on every item in the given list of dependencies, but cannot have a dependency that is not in the list.
             </summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -1131,6 +1131,12 @@
             </summary>
             <returns>A condition that tests classes against a given criteria.</returns>
         </member>
+        <member name="M:NetArchTest.Rules.PredicateList.Slice">
+            <summary>
+            Allows dividing types into groups, also called slices.
+            </summary>
+            <returns></returns>
+        </member>
         <member name="M:NetArchTest.Rules.PredicateList.GetTypeDefinitions">
             <summary>
             Returns the type definitions returned by these predicate.
@@ -1594,6 +1600,94 @@
             <param name="rule">An instance of the custom rule.</param>
             <returns>An updated set of conditions that can be applied to a list of types.</returns>
         </member>
+        <member name="T:NetArchTest.Rules.IFailingType">
+            <summary>
+            Type that failed the test.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.IFailingType.Type">
+            <summary>
+            System.Type that failed the test.
+            </summary>
+            <remarks>
+            This property may be null if the test project does not have a direct dependency on the type.
+            </remarks>
+        </member>
+        <member name="P:NetArchTest.Rules.IFailingType.TypeName">
+            <summary>
+            Name of the type that failed the test.
+            </summary>       
+        </member>
+        <member name="T:NetArchTest.Rules.ISliceConditionList">
+            <summary>
+            Executor of condition.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.ISliceConditionList.GetResult">
+            <summary>
+            Returns an indication of whether all the selected types satisfy the conditions.
+            </summary>
+            <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
+        </member>
+        <member name="T:NetArchTest.Rules.ISliceConditions">
+            <summary>
+            A set of conditions that can be applied to slices of types.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.ISliceConditions.NotHaveDependenciesBetweenSlices">
+            <summary>
+            Selects types that do not have dependencies on types from other slices.
+            </summary>        
+        </member>
+        <member name="M:NetArchTest.Rules.ISliceConditions.HaveDependenciesBetweenSlices">
+            <summary>
+            Selects types that have some dependencies on types from other slices.
+            </summary>  
+        </member>
+        <member name="T:NetArchTest.Rules.ISliceList">
+            <summary>
+            Link between predicate and condition.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.ISliceList.Should">
+            <summary>
+            Links a predicate defining a set of classes to a condition that tests them.
+            </summary>
+        </member>
+        <member name="M:NetArchTest.Rules.ISliceList.ShouldNot">
+            <summary>
+            Links a predicate defining a set of classes to a condition that tests them.
+            </summary>
+        </member>
+        <member name="T:NetArchTest.Rules.ISlices">
+            <summary>
+            Allows dividing types into groups, also called slices.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.ISlices.ByNamespacePrefix(System.String)">
+            <summary>
+            Divides types into groups/slices according to the prefix pattern.
+            It only selects types which namespaces start with a given prefix, rest of the types are ignored.
+            Groups are defined by the first part of the namespace that is right after prefix:
+            namespacePrefix.(groupName).restOfNamespace
+            </summary>      
+        </member>
+        <member name="T:NetArchTest.Rules.ITestResult">
+            <summary>
+            Defines a result from a test carried out on a <see cref="T:NetArchTest.Rules.ISliceConditionList"/>.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.ITestResult.IsSuccessful">
+            <summary>
+            Gets a flag indicating the success or failure of the test.
+            </summary>
+        </member>
+        <member name="P:NetArchTest.Rules.ITestResult.FailingTypes">
+            <summary>
+            Gets a list of the types that failed the test.
+            </summary>
+        </member>
         <member name="T:NetArchTest.Rules.TestResult">
             <summary>
             Defines a result from a test carried out on a <see cref="T:NetArchTest.Rules.ConditionList"/>.
@@ -1724,6 +1818,12 @@
         <member name="M:NetArchTest.Rules.Types.Should">
             <summary>
             Applies a set of conditions to the list of types.
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:NetArchTest.Rules.Types.Slice">
+            <summary>
+            Allows dividing types into groups, also called slices.
             </summary>
             <returns></returns>
         </member>

--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -35,11 +35,6 @@
             return new Conditions(_sequence.Execute(_types), true);
         }
 
-        public ISlices Slice()
-        {
-            return new NetArchTest.Rules.Slices.Slices(_sequence.Execute(_types));
-        }
-
         /// <summary>
         /// Links a predicate defining a set of classes to a condition that tests them.
         /// </summary>
@@ -48,6 +43,17 @@
         {
             return new Conditions(_sequence.Execute(_types), false);
         }
+
+        /// <summary>
+        /// Allows dividing types into groups, also called slices.
+        /// </summary>
+        /// <returns></returns>
+        public ISlices Slice()
+        {
+            return new NetArchTest.Rules.Slices.Slices(_sequence.Execute(_types));
+        }
+
+        
 
         /// <summary>
         /// Returns the type definitions returned by these predicate.

--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -35,6 +35,11 @@
             return new Conditions(_sequence.Execute(_types), true);
         }
 
+        public ISlices Slice()
+        {
+            return new NetArchTest.Rules.Slices.Slices(_sequence.Execute(_types));
+        }
+
         /// <summary>
         /// Links a predicate defining a set of classes to a condition that tests them.
         /// </summary>

--- a/src/NetArchTest.Rules/Slices/FailingType.cs
+++ b/src/NetArchTest.Rules/Slices/FailingType.cs
@@ -1,0 +1,37 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+    using Mono.Cecil;
+    using NetArchTest.Rules.Extensions;
+
+    [DebuggerDisplay("{TypeName}")]
+    internal sealed class FailingType : IFailingType
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly TypeDefinition _monoTypeDefinition;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly Lazy<Type> _type;
+
+        public FailingType(TypeDefinition monoTypeDefinition)
+        {
+            _monoTypeDefinition = monoTypeDefinition;
+            _type = new Lazy<Type>(() =>
+            {
+                Type type = null;
+                try
+                {
+                    type = _monoTypeDefinition.ToType();
+                }
+                catch { }
+                return type;
+            });
+        }
+
+
+        public Type Type { get => _type.Value; }
+        public string TypeName { get => _monoTypeDefinition.FullName; }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/IFailingType.cs
+++ b/src/NetArchTest.Rules/Slices/IFailingType.cs
@@ -5,8 +5,23 @@
     using System.Text;
     using Mono.Cecil;
 
+    /// <summary>
+    /// Type that failed the test.
+    /// </summary>
     public interface IFailingType
     {
-        TypeDefinition MonoTypeDefinition { get;  }
+        /// <summary>
+        /// System.Type that failed the test.
+        /// </summary>
+        /// <remarks>
+        /// This property may be null if the test project does not have a direct dependency on the type.
+        /// </remarks>
+        Type Type { get;  }
+
+
+        /// <summary>
+        /// Name of the type that failed the test.
+        /// </summary>       
+        string TypeName { get; }
     }
 }

--- a/src/NetArchTest.Rules/Slices/IFailingType.cs
+++ b/src/NetArchTest.Rules/Slices/IFailingType.cs
@@ -1,0 +1,12 @@
+﻿namespace NetArchTest.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Mono.Cecil;
+
+    public interface IFailingType
+    {
+        TypeDefinition MonoTypeDefinition { get;  }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
@@ -1,9 +1,5 @@
 ﻿namespace NetArchTest.Rules
-{
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
+{    
     public interface ISliceConditionList
     {
         ITestResult GetResult();

--- a/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
@@ -1,7 +1,15 @@
 ﻿namespace NetArchTest.Rules
 {    
+    /// <summary>
+    /// Executor of condition.
+    /// </summary>
     public interface ISliceConditionList
     {
+        /// <summary>
+        /// Returns an indication of whether all the selected types satisfy the conditions.
+        /// </summary>
+        /// <returns>An indication of whether the conditions are true, along with a list of types failing the check if they are not.</returns>
+
         ITestResult GetResult();
     }
 }

--- a/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceConditionList.cs
@@ -1,0 +1,11 @@
+﻿namespace NetArchTest.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public interface ISliceConditionList
+    {
+        ITestResult GetResult();
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ISliceConditions.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceConditions.cs
@@ -1,0 +1,9 @@
+﻿namespace NetArchTest.Rules
+{
+    public interface ISliceConditions
+    {
+        ISliceConditionList NotHaveDependenciesBetweenSlices();
+
+        ISliceConditionList HaveDependenciesBetweenSlices();
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ISliceConditions.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceConditions.cs
@@ -1,9 +1,19 @@
 ﻿namespace NetArchTest.Rules
 {
+    /// <summary>
+    /// A set of conditions that can be applied to slices of types.
+    /// </summary>
     public interface ISliceConditions
     {
+        /// <summary>
+        /// Selects types that do not have dependencies on types from other slices.
+        /// </summary>        
         ISliceConditionList NotHaveDependenciesBetweenSlices();
 
+
+        /// <summary>
+        /// Selects types that have some dependencies on types from other slices.
+        /// </summary>  
         ISliceConditionList HaveDependenciesBetweenSlices();
     }
 }

--- a/src/NetArchTest.Rules/Slices/ISliceList.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceList.cs
@@ -1,0 +1,8 @@
+﻿namespace NetArchTest.Rules
+{
+    public interface ISliceList
+    {
+        ISliceConditions Should();
+        ISliceConditions ShouldNot();
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ISliceList.cs
+++ b/src/NetArchTest.Rules/Slices/ISliceList.cs
@@ -1,8 +1,18 @@
 ﻿namespace NetArchTest.Rules
 {
+    /// <summary>
+    /// Link between predicate and condition.
+    /// </summary>
     public interface ISliceList
     {
+        /// <summary>
+        /// Links a predicate defining a set of classes to a condition that tests them.
+        /// </summary>
         ISliceConditions Should();
+
+        /// <summary>
+        /// Links a predicate defining a set of classes to a condition that tests them.
+        /// </summary>
         ISliceConditions ShouldNot();
     }
 }

--- a/src/NetArchTest.Rules/Slices/ISlices.cs
+++ b/src/NetArchTest.Rules/Slices/ISlices.cs
@@ -2,6 +2,6 @@
 {
     public interface ISlices
     {
-        ISliceList ByPrefix(string name);
+        ISliceList ByNamespacePrefix(string name);
     }
 }

--- a/src/NetArchTest.Rules/Slices/ISlices.cs
+++ b/src/NetArchTest.Rules/Slices/ISlices.cs
@@ -1,0 +1,7 @@
+﻿namespace NetArchTest.Rules
+{
+    public interface ISlices
+    {
+        ISliceList ByPrefix(string name);
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ISlices.cs
+++ b/src/NetArchTest.Rules/Slices/ISlices.cs
@@ -1,7 +1,17 @@
 ﻿namespace NetArchTest.Rules
 {
+    /// <summary>
+    /// Allows dividing types into groups, also called slices.
+    /// </summary>
+    /// <returns></returns>
     public interface ISlices
     {
-        ISliceList ByNamespacePrefix(string name);
+        /// <summary>
+        /// Divides types into groups/slices according to the prefix pattern.
+        /// It only selects types which namespaces start with a given prefix, rest of the types are ignored.
+        /// Groups are defined by the first part of the namespace that is right after prefix:
+        /// namespacePrefix.(groupName).restOfNamespace
+        /// </summary>      
+        ISliceList ByNamespacePrefix(string prefix);
     }
 }

--- a/src/NetArchTest.Rules/Slices/ITestResult.cs
+++ b/src/NetArchTest.Rules/Slices/ITestResult.cs
@@ -1,0 +1,12 @@
+﻿namespace NetArchTest.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public interface ITestResult
+    {
+        bool IsSuccessful { get; }
+        IEnumerable<IFailingType> FailingTypes { get; }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/ITestResult.cs
+++ b/src/NetArchTest.Rules/Slices/ITestResult.cs
@@ -4,9 +4,21 @@
     using System.Collections.Generic;
     using System.Text;
 
+
+    /// <summary>
+    /// Defines a result from a test carried out on a <see cref="ISliceConditionList"/>.
+    /// </summary>
     public interface ITestResult
     {
+        /// <summary>
+        /// Gets a flag indicating the success or failure of the test.
+        /// </summary>
         bool IsSuccessful { get; }
-        IEnumerable<IFailingType> FailingTypes { get; }
+
+
+        /// <summary>
+        /// Gets a list of the types that failed the test.
+        /// </summary>
+        IReadOnlyList<IFailingType> FailingTypes { get; }
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
@@ -6,7 +6,7 @@
 
     internal sealed class HaveDependenciesBetweenSlices : IFilter
     {
-        public IEnumerable<TypeResult> Execute(SlicedTypes slices)
+        public IEnumerable<TypeResult> Execute(SlicedTypes slicedTypes)
         {
             return null;
         }

--- a/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
@@ -2,13 +2,35 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
+    using Mono.Cecil;
+    using NetArchTest.Rules.Dependencies;
 
     internal sealed class HaveDependenciesBetweenSlices : IFilter
     {
         public IEnumerable<TypeResult> Execute(SlicedTypes slicedTypes)
         {
-            return null;
+            var dependencySearch = new DependencySearch();
+            var result = new List<TypeResult>(slicedTypes.TypeCount);
+
+            for (int i = 0; i < slicedTypes.Slices.Count; i++)
+            {
+                var slice = slicedTypes.Slices[i];
+                var dependencies = slicedTypes.Slices.Where((_, index) => index != i).Select(x => x.Name).ToList();
+
+                var foundTypes =  dependencySearch.FindTypesThatHaveDependencyOnAny(slice.Types, dependencies);
+                var lookup = new HashSet<TypeDefinition>(foundTypes);
+
+                foreach (var type in slice.Types)
+                {
+                    bool isPassing = lookup.Contains(type);
+                    var typeResult = new TypeResult(type, isPassing);                    
+                    result.Add(typeResult);
+                }
+            }
+
+            return result;
         }
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Filters/HaveDependenciesBetweenSlices.cs
@@ -1,0 +1,14 @@
+﻿namespace NetArchTest.Rules.Slices.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal sealed class HaveDependenciesBetweenSlices : IFilter
+    {
+        public IEnumerable<TypeResult> Execute(SlicedTypes slices)
+        {
+            return null;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/IFilter.cs
+++ b/src/NetArchTest.Rules/Slices/Model/IFilter.cs
@@ -1,0 +1,11 @@
+﻿namespace NetArchTest.Rules.Slices.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    interface IFilter
+    {
+        IEnumerable<TypeResult> Execute(SlicedTypes slices);
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/IFilter.cs
+++ b/src/NetArchTest.Rules/Slices/Model/IFilter.cs
@@ -6,6 +6,6 @@
 
     interface IFilter
     {
-        IEnumerable<TypeResult> Execute(SlicedTypes slices);
+        IEnumerable<TypeResult> Execute(SlicedTypes slicedTypes);
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/Slice.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Slice.cs
@@ -1,0 +1,20 @@
+﻿namespace NetArchTest.Rules.Slices.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Mono.Cecil;
+
+    internal sealed class Slice
+    {
+        public string Name { get;  }
+        public IEnumerable<TypeDefinition> Types { get;  }
+
+
+        public Slice(string sliceName, List<TypeDefinition> types)
+        {
+            Name = sliceName;
+            Types = types;
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/SlicedTypes.cs
+++ b/src/NetArchTest.Rules/Slices/Model/SlicedTypes.cs
@@ -1,11 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NetArchTest.Rules.Slices.Model
+﻿namespace NetArchTest.Rules.Slices.Model
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
     internal sealed class SlicedTypes
     {
-        public int TypeCount { get; }
+        public int TypeCount { get; }       
+
+        public IReadOnlyList<Slice> Slices { get; }
+
+
+        public SlicedTypes(int typeCount, List<Slice> slices)
+        {
+            TypeCount = typeCount;
+            Slices = slices;
+        }
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/SlicedTypes.cs
+++ b/src/NetArchTest.Rules/Slices/Model/SlicedTypes.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NetArchTest.Rules.Slices.Model
+{
+    internal sealed class SlicedTypes
+    {
+        public int TypeCount { get; }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/Slicer.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Slicer.cs
@@ -1,14 +1,54 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace NetArchTest.Rules.Slices.Model
+﻿namespace NetArchTest.Rules.Slices.Model
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using Mono.Cecil;
+    using NetArchTest.Rules.Extensions;
+
     internal sealed class  Slicer
     {
-        public SlicedTypes SliceByPrefix(IEnumerable<Mono.Cecil.TypeDefinition> _types, string prefix)
+        public SlicedTypes SliceByNamespacePrefix(IEnumerable<TypeDefinition> types, string prefix)
         {
-            return new SlicedTypes();
+            string prefixWithDot = "";
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                prefixWithDot = prefix;
+                if (prefixWithDot.Last() != '.')
+                {
+                    prefixWithDot = prefixWithDot + ".";
+                }
+            }
+
+            var groupedTypes = new Dictionary<string, List<TypeDefinition>>();
+            int typeCount = 0;
+
+            foreach (var type in types)
+            {
+                var typeNamespace = type.GetNamespace();
+                if (typeNamespace.StartsWith(prefixWithDot))
+                {
+                    ++typeCount;
+                    int nextDotIndex = typeNamespace.IndexOf('.', prefixWithDot.Length);
+                    int startIndex = prefixWithDot.Length;
+                    int endIndex = nextDotIndex > -1 ? nextDotIndex : typeNamespace.Length;
+                    string sliceName = typeNamespace.Substring(0, endIndex);                                     
+
+                    if (groupedTypes.TryGetValue(sliceName, out var list))
+                    {
+                        list.Add(type);
+                    }
+                    else
+                    {
+                        groupedTypes[sliceName] = new List<TypeDefinition>() { type };
+                    }
+                }
+            }
+
+            var slices = groupedTypes.Select((x) => new Slice(x.Key, x.Value)).ToList();
+
+            return new SlicedTypes(typeCount, slices);
         }
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/Slicer.cs
+++ b/src/NetArchTest.Rules/Slices/Model/Slicer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NetArchTest.Rules.Slices.Model
+{
+    internal sealed class  Slicer
+    {
+        public SlicedTypes SliceByPrefix(IEnumerable<Mono.Cecil.TypeDefinition> _types, string prefix)
+        {
+            return new SlicedTypes();
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
+++ b/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
@@ -5,20 +5,17 @@
     using System.Text;
     using Mono.Cecil;
 
-    internal sealed class TypeResult : IFailingType
+    internal sealed class TypeResult 
     { 
         public TypeDefinition Type { get;  }
         public bool IsPassing { get;  }
-        public string Reason { get; set; }
+        
 
 
         public TypeResult(TypeDefinition type, bool isPassing)
         {
             Type = type;
             IsPassing = isPassing;
-        }
-
-
-        TypeDefinition IFailingType.MonoTypeDefinition { get => Type; }
+        }       
     }
 }

--- a/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
+++ b/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
@@ -1,0 +1,16 @@
+﻿namespace NetArchTest.Rules.Slices.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Mono.Cecil;
+
+    internal sealed class TypeResult : IFailingType
+    {
+        public TypeDefinition Type { get; set; }
+        public bool IsPassing { get; set; }
+        public string Reason { get; set; }
+
+        TypeDefinition IFailingType.MonoTypeDefinition { get => Type; }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
+++ b/src/NetArchTest.Rules/Slices/Model/TypeResult.cs
@@ -6,10 +6,18 @@
     using Mono.Cecil;
 
     internal sealed class TypeResult : IFailingType
-    {
-        public TypeDefinition Type { get; set; }
-        public bool IsPassing { get; set; }
+    { 
+        public TypeDefinition Type { get;  }
+        public bool IsPassing { get;  }
         public string Reason { get; set; }
+
+
+        public TypeResult(TypeDefinition type, bool isPassing)
+        {
+            Type = type;
+            IsPassing = isPassing;
+        }
+
 
         TypeDefinition IFailingType.MonoTypeDefinition { get => Type; }
     }

--- a/src/NetArchTest.Rules/Slices/SliceConditionList.cs
+++ b/src/NetArchTest.Rules/Slices/SliceConditionList.cs
@@ -9,13 +9,13 @@
     internal sealed class SliceConditionList : ISliceConditionList
     {
         private readonly IFilter _filter;
-        private readonly SlicedTypes _slices;
+        private readonly SlicedTypes _slicedTypes;
         private readonly bool _should;
 
-        public SliceConditionList(IFilter filter, SlicedTypes slices, bool should)
+        public SliceConditionList(IFilter filter, SlicedTypes slicedTypes, bool should)
         {
             _filter = filter;
-            _slices = slices;
+            _slicedTypes = slicedTypes;
             _should = should;
         }
 
@@ -23,23 +23,23 @@
 
         public ITestResult GetResult()
         {
-            var filterResults = _filter.Execute(_slices);
+            var filteredTypes = _filter.Execute(_slicedTypes);
 
-            bool successIsWhen = _should;
-            bool success = filterResults.All(x => x.IsPassing == successIsWhen);
-
-            if (filterResults.Count() != _slices.TypeCount)
+            if (filteredTypes.Count() != _slicedTypes.TypeCount)
             {
                 throw new Exception("Filter returned wrong number of results!");
             }
 
-            if (success)
+            bool successIsWhen = _should;
+            bool isSuccessful = filteredTypes.All(x => x.IsPassing == successIsWhen);           
+
+            if (isSuccessful)
             {
                 return TestResult.Success();
             }
             else
             {
-                var failingTypes = filterResults.Where(x => x.IsPassing == !successIsWhen);
+                var failingTypes = filteredTypes.Where(x => x.IsPassing == !successIsWhen);
                 return TestResult.Failure(failingTypes);
             }
         }

--- a/src/NetArchTest.Rules/Slices/SliceConditionList.cs
+++ b/src/NetArchTest.Rules/Slices/SliceConditionList.cs
@@ -1,0 +1,47 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NetArchTest.Rules.Slices.Model;
+   
+
+    internal sealed class SliceConditionList : ISliceConditionList
+    {
+        private readonly IFilter _filter;
+        private readonly SlicedTypes _slices;
+        private readonly bool _should;
+
+        public SliceConditionList(IFilter filter, SlicedTypes slices, bool should)
+        {
+            _filter = filter;
+            _slices = slices;
+            _should = should;
+        }
+
+
+
+        public ITestResult GetResult()
+        {
+            var filterResults = _filter.Execute(_slices);
+
+            bool successIsWhen = _should;
+            bool success = filterResults.All(x => x.IsPassing == successIsWhen);
+
+            if (filterResults.Count() != _slices.TypeCount)
+            {
+                throw new Exception("Filter returned wrong number of results!");
+            }
+
+            if (success)
+            {
+                return TestResult.Success();
+            }
+            else
+            {
+                var failingTypes = filterResults.Where(x => x.IsPassing == !successIsWhen);
+                return TestResult.Failure(failingTypes);
+            }
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/SliceConditions.cs
+++ b/src/NetArchTest.Rules/Slices/SliceConditions.cs
@@ -1,0 +1,32 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using NetArchTest.Rules.Slices.Model;
+
+
+    internal sealed class SliceConditions : ISliceConditions
+    {
+        private readonly SlicedTypes _slices;
+        private readonly bool _should;
+
+
+        public SliceConditions(SlicedTypes slices, bool should)
+        {
+            _slices = slices;
+            _should = should;
+        }
+
+
+        public ISliceConditionList HaveDependenciesBetweenSlices()
+        {
+            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slices, _should);
+        }
+
+        public ISliceConditionList NotHaveDependenciesBetweenSlices()
+        {
+            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slices, !_should);
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/SliceConditions.cs
+++ b/src/NetArchTest.Rules/Slices/SliceConditions.cs
@@ -8,25 +8,25 @@
 
     internal sealed class SliceConditions : ISliceConditions
     {
-        private readonly SlicedTypes _slices;
+        private readonly SlicedTypes _slicedTypes;
         private readonly bool _should;
 
 
         public SliceConditions(SlicedTypes slices, bool should)
         {
-            _slices = slices;
+            _slicedTypes = slices;
             _should = should;
         }
 
 
         public ISliceConditionList HaveDependenciesBetweenSlices()
         {
-            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slices, _should);
+            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slicedTypes, _should);
         }
 
         public ISliceConditionList NotHaveDependenciesBetweenSlices()
         {
-            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slices, !_should);
+            return new SliceConditionList(new HaveDependenciesBetweenSlices(), _slicedTypes, !_should);
         }
     }
 }

--- a/src/NetArchTest.Rules/Slices/SliceList.cs
+++ b/src/NetArchTest.Rules/Slices/SliceList.cs
@@ -1,0 +1,27 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using NetArchTest.Rules.Slices.Model;
+
+    internal sealed class SliceList : ISliceList
+    {
+        private readonly SlicedTypes _slices;
+
+        public SliceList(SlicedTypes slices)
+        {
+            _slices = slices;
+        }
+
+        public ISliceConditions Should()
+        {
+            return new SliceConditions(_slices, true);
+        }
+
+        public ISliceConditions ShouldNot()
+        {
+            return new SliceConditions(_slices, false);
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/SliceList.cs
+++ b/src/NetArchTest.Rules/Slices/SliceList.cs
@@ -7,21 +7,27 @@
 
     internal sealed class SliceList : ISliceList
     {
-        private readonly SlicedTypes _slices;
+        private readonly SlicedTypes _slicedTypes;
 
-        public SliceList(SlicedTypes slices)
+        public SliceList(SlicedTypes slicedTypes)
         {
-            _slices = slices;
+            _slicedTypes = slicedTypes;
         }
 
         public ISliceConditions Should()
         {
-            return new SliceConditions(_slices, true);
+            return new SliceConditions(_slicedTypes, true);
         }
 
         public ISliceConditions ShouldNot()
         {
-            return new SliceConditions(_slices, false);
+            return new SliceConditions(_slicedTypes, false);
+        }
+
+
+        public SlicedTypes GetSlicedTypes()
+        {
+            return _slicedTypes;
         }
     }
 }

--- a/src/NetArchTest.Rules/Slices/Slices.cs
+++ b/src/NetArchTest.Rules/Slices/Slices.cs
@@ -1,0 +1,26 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Mono.Cecil;
+    using NetArchTest.Rules.Slices.Model;
+
+    internal sealed class Slices : ISlices
+    {
+        private readonly IEnumerable<TypeDefinition> _types;
+
+        public Slices(IEnumerable<TypeDefinition> types)
+        {
+            _types = types;
+        }
+
+
+        public ISliceList ByPrefix(string prefix)
+        {
+            var slicer = new Slicer();
+            var slices = slicer.SliceByPrefix(_types, prefix);
+            return new SliceList(slices);
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/Slices.cs
+++ b/src/NetArchTest.Rules/Slices/Slices.cs
@@ -16,11 +16,11 @@
         }
 
 
-        public ISliceList ByPrefix(string prefix)
-        {
+        public ISliceList ByNamespacePrefix(string prefix)
+        {            
             var slicer = new Slicer();
-            var slices = slicer.SliceByPrefix(_types, prefix);
-            return new SliceList(slices);
+            var slicedTypes = slicer.SliceByNamespacePrefix(_types, prefix);
+            return new SliceList(slicedTypes);
         }
     }
 }

--- a/src/NetArchTest.Rules/Slices/TestResult.cs
+++ b/src/NetArchTest.Rules/Slices/TestResult.cs
@@ -1,0 +1,35 @@
+﻿namespace NetArchTest.Rules.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using NetArchTest.Rules.Slices.Model;
+
+    internal sealed class TestResult : ITestResult
+    {
+        public bool IsSuccessful { get; private set; }
+        public IEnumerable<IFailingType> FailingTypes { get; private set; }
+
+
+
+
+
+     
+        internal static TestResult Success()
+        {
+            return new TestResult
+            {
+                IsSuccessful = true
+            };
+        }
+       
+        internal static TestResult Failure(IEnumerable<TypeResult> failingTypes)
+        {
+            return new TestResult
+            {
+                IsSuccessful = false,
+                FailingTypes = failingTypes
+            };
+        }
+    }
+}

--- a/src/NetArchTest.Rules/Slices/TestResult.cs
+++ b/src/NetArchTest.Rules/Slices/TestResult.cs
@@ -10,10 +10,6 @@
         public bool IsSuccessful { get; private set; }
         public IEnumerable<IFailingType> FailingTypes { get; private set; }
 
-
-
-
-
      
         internal static TestResult Success()
         {

--- a/src/NetArchTest.Rules/Slices/TestResult.cs
+++ b/src/NetArchTest.Rules/Slices/TestResult.cs
@@ -2,13 +2,17 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
     using System.Text;
     using NetArchTest.Rules.Slices.Model;
 
+    [DebuggerDisplay("FailingTypes = {FailingTypes.Count}")]
     internal sealed class TestResult : ITestResult
     {
         public bool IsSuccessful { get; private set; }
-        public IEnumerable<IFailingType> FailingTypes { get; private set; }
+        
+        public IReadOnlyList<IFailingType> FailingTypes { get; private set; }
 
      
         internal static TestResult Success()
@@ -24,7 +28,8 @@
             return new TestResult
             {
                 IsSuccessful = false,
-                FailingTypes = failingTypes
+                
+                FailingTypes = failingTypes.Select(x => new FailingType(x.Type)).ToArray()
             };
         }
     }

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -304,6 +304,11 @@
             return new Conditions(_types, true);
         }
 
+        public ISlices Slice()
+        {
+            return new NetArchTest.Rules.Slices.Slices(_types);
+        }
+
         /// <summary>
         /// Applies a negative set of conditions to the list of types.
         /// </summary>

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -304,6 +304,10 @@
             return new Conditions(_types, true);
         }
 
+        /// <summary>
+        /// Allows dividing types into groups, also called slices.
+        /// </summary>
+        /// <returns></returns>
         public ISlices Slice()
         {
             return new NetArchTest.Rules.Slices.Slices(_types);

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyLocationTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyLocationTests.cs
@@ -6,8 +6,8 @@
     using Xunit;
 
     /// <summary>
-    /// This tests collection verifies that dependency search checks every posible place in C# code.
-    /// It search for ExampleDependency, when in given place there is no posiblity of using ExampleDependency
+    /// This tests collection verifies that dependency search checks every possible place in C# code.
+    /// It search for ExampleDependency, when in given place there is no possibility of using ExampleDependency
     /// then it looks for: AttributeDependency or ExceptionDependency 
     /// </summary>
     [CollectionDefinition("Dependency Search - location tests ")]

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -9,7 +9,7 @@
     using Pointer = TestStructure.Dependencies.Search.DependencyType.Pointer;
 
     /// <summary>
-    /// This tests collection verifies that dependency search checks every posible type.    
+    /// This tests collection verifies that dependency search checks every possible type.    
     /// </summary>
     [CollectionDefinition("Dependency Search - type tests ")]
     public class DependencyTypeTests

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/SearchTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/SearchTypeTests.cs
@@ -173,7 +173,7 @@
                 .GetTypeDefinitions();
 
             // Act
-            var result = search.FindTypesThatOnlyOnlyHaveDependenciesOnAll(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System" });
+            var result = search.FindTypesThatOnlyHaveDependenciesOnAll(typeList, new string[] { typeof(Dependency_1).FullName, typeof(Dependency_2).FullName, "System" });
 
             // Assert           
             Assert.Equal(1, result.Count);

--- a/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
@@ -49,6 +49,10 @@
                                .GetResult();
 
             Assert.False(testResult.IsSuccessful);
+
+
+
+            Types.InCurrentDomain().Slice().ByNamespacePrefix("").Should().NotHaveDependenciesBetweenSlices().GetResult();
         }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
@@ -1,0 +1,29 @@
+﻿namespace NetArchTest.Rules.UnitTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using NetArchTest.Rules.Slices;
+    using NetArchTest.TestStructure.Dependencies.Examples;
+    using Xunit;
+
+    public class SlicesTests
+    {
+        [Fact(DisplayName = "Types are divided correctly into slices for a valid tree")]
+        public void TypesAreDividedCorrectlyIntoSlicesForValidTree()
+        {
+            var slicedTypes = (Types.InAssembly(typeof(ExampleDependency).Assembly)
+                               .Slice()
+                               .ByNamespacePrefix("NetArchTest.TestStructure.Slices.ValidTree") as SliceList).GetSlicedTypes();
+
+            Assert.Equal(9, slicedTypes.TypeCount);
+            Assert.Equal(3, slicedTypes.Slices.Count());
+            Assert.Equal(5, slicedTypes.Slices.Where(x => x.Name == "NetArchTest.TestStructure.Slices.ValidTree.FeatureA").First().Types.Count());
+            Assert.Equal(3, slicedTypes.Slices.Where(x => x.Name == "NetArchTest.TestStructure.Slices.ValidTree.FeatureB").First().Types.Count());
+            Assert.Single(slicedTypes.Slices.Where(x => x.Name == "NetArchTest.TestStructure.Slices.ValidTree.FeatureC").First().Types);
+        }
+
+
+    }
+}

--- a/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/SlicesTests.cs
@@ -25,5 +25,30 @@
         }
 
 
+        [Fact(DisplayName = "Valid tree does not have dependencies between slices")]
+        public void ValidTreeDoesNotHaveDependenciesBetweenSlices()
+        {
+            var testResult = Types.InAssembly(typeof(ExampleDependency).Assembly)
+                               .Slice()
+                               .ByNamespacePrefix("NetArchTest.TestStructure.Slices.ValidTree")
+                               .Should()
+                               .NotHaveDependenciesBetweenSlices()
+                               .GetResult();
+
+            Assert.True(testResult.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Invalid tree has dependencies between slices")]
+        public void InvalidTreeHasDependenciesBetweenSlices()
+        {
+            var testResult = Types.InAssembly(typeof(ExampleDependency).Assembly)
+                               .Slice()
+                               .ByNamespacePrefix("NetArchTest.TestStructure.Slices.InvalidTree")
+                               .Should()
+                               .NotHaveDependenciesBetweenSlices()
+                               .GetResult();
+
+            Assert.False(testResult.IsSuccessful);
+        }
     }
 }

--- a/test/NetArchTest.TestStructure/Slices/InvalidTree.cs
+++ b/test/NetArchTest.TestStructure/Slices/InvalidTree.cs
@@ -1,0 +1,52 @@
+﻿namespace NetArchTest.TestStructure.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Text;
+    
+
+    namespace InvalidTree
+    {
+        namespace FeatureA
+        {
+            using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.App;
+            namespace App
+            {
+                using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+
+                class AppService { AggregateRoot root; }
+            }
+            namespace Domain
+            {
+                class ValueObject { }
+                class AggregateRoot { ValueObject value; }
+            }
+            namespace Infrastructure
+            {
+                namespace Persistence 
+                {
+                    using NetArchTest.TestStructure.Slices.InvalidTree.FeatureB;
+                    using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+                    class Repository {  DAO dao; }
+                }
+            }
+            class FeatureA : FeatureBase { AppService app; }
+        }
+        namespace FeatureB
+        {
+            class AppService { DAO dao;  }
+            class DAO { }
+            class FeatureB : FeatureBase { AppService app; }
+        }
+        namespace FeatureC
+        {            
+            class FeatureC : FeatureBase { }
+        }
+
+        class FeatureBase
+        {
+
+        }
+    }
+}

--- a/test/NetArchTest.TestStructure/Slices/ValidTree.cs
+++ b/test/NetArchTest.TestStructure/Slices/ValidTree.cs
@@ -1,0 +1,51 @@
+﻿namespace NetArchTest.TestStructure.Slices
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Dynamic;
+    using System.Text;
+    
+
+    namespace ValidTree
+    {
+        namespace FeatureA
+        {
+            using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.App;
+            namespace App
+            {
+                using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+
+                class AppService { AggregateRoot root; }
+            }
+            namespace Domain
+            {
+                class ValueObject { }
+                class AggregateRoot { ValueObject value; }
+            }
+            namespace Infrastructure
+            {
+                namespace Persistence 
+                {
+                    using NetArchTest.TestStructure.Slices.ValidTree.FeatureA.Domain;
+                    class Repository {  AggregateRoot root; }
+                }
+            }
+            class FeatureA : FeatureBase { AppService app; }
+        }
+        namespace FeatureB
+        {
+            class AppService { DAO dao;  }
+            class DAO { }
+            class FeatureB : FeatureBase { AppService app; }
+        }
+        namespace FeatureC
+        {            
+            class FeatureC : FeatureBase { }
+        }
+
+        class FeatureBase
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
ArchUnit has slices, #people want slices #50, so it is time to introduces slices to NetArchTest. 
It is a very simple implementation, not that sophisticated as in ArchUnit, but it should cover most of the cases. 

```csharp
Types.InAssembly(typeof(ExampleDependency).Assembly)
     .Slice()
     .ByNamespacePrefix("ConsoleApp10.Features")
     .Should()
     .NotHaveDependenciesBetweenSlices()
     .GetResult();
```

There is only one way, at least for now, to divide types into slices `ByNamespacePrefix(string prefix)` and it works as follows:
1) It only selects types which namespaces start with a given prefix, rest of the types are ignored.
2) Then groups/slices are defined by the first part of the namespace that is right after prefix:
 `namespacePrefix.(groupName).restOfNamespace`
3) Types with the same groupName part will be placed in the same slice. If groupName is empty for a given type, the type will be also ignored (`BaseFeature` class from image)

Example, the above piece of code, will divide these types into three slices:
![image](https://user-images.githubusercontent.com/11632757/98448733-9f508a80-212e-11eb-86d7-11c28a038c47.png)

When we already have our types divided into slices, we can apply only one available right now condition: `NotHaveDependenciesBetweenSlices()`. As the name suggest it detects if any dependencies exist between slices. Any dependency from slice to type that is not part of any other slice is allowed.

![image](https://user-images.githubusercontent.com/11632757/98449020-919c0480-2130-11eb-97c4-72960d83dce2.png)

![image](https://user-images.githubusercontent.com/11632757/98449070-edff2400-2130-11eb-90ce-fd2daf61719b.png)

