### PR TITLE
fix: analyze string const by comparing with full name

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DataStructures/CachedNamespaceTree.cs
+++ b/src/NetArchTest.Rules/Dependencies/DataStructures/CachedNamespaceTree.cs
@@ -32,5 +32,10 @@
             }
             return node.value;
         }
+
+        public IEnumerable<string> GetAllMatchingNames(string fullName)
+        {
+            return _searchTree.GetAllMatchingNames(fullName).ToArray();
+        }
     }
 }

--- a/src/NetArchTest.Rules/Dependencies/DataStructures/ISearchTree.cs
+++ b/src/NetArchTest.Rules/Dependencies/DataStructures/ISearchTree.cs
@@ -6,6 +6,7 @@
     internal interface ISearchTree
     {
         IEnumerable<string> GetAllMatchingNames(TypeReference type);
+        IEnumerable<string> GetAllMatchingNames(string fullName);
         int TerminatedNodesCount { get; }
     }
 }

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -96,8 +96,7 @@
                 {
                     CheckCustomAttributes(field);
                     CheckTypeReference(field.FieldType);
-                    if (field.HasConstant &&
-                        field.FieldType.FullName == typeof(string).FullName)
+                    if (field.HasConstant && field.FieldType.FullName == typeof(string).FullName)
                     {
                         _result.CheckDependency(field.Constant.ToString());
                     }

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -96,6 +96,11 @@
                 {
                     CheckCustomAttributes(field);
                     CheckTypeReference(field.FieldType);
+                    if (field.HasConstant &&
+                        field.FieldType.FullName == typeof(string).FullName)
+                    {
+                        _result.CheckDependency(field.Constant.ToString());
+                    }
                 }
             }
         }
@@ -140,19 +145,19 @@
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodHeader(method);
+                    CheckMethodHeader(method);
                 }
 
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodBodyVariables(method);
+                    CheckMethodBodyVariables(method);
                 }
 
                 foreach (var method in typeToCheck.Methods)
                 {
                     if (_result.CanWeSkipFurtherSearch()) return;
-                    this.CheckMethodBodyInstructions(method);
+                    CheckMethodBodyInstructions(method);
                 }
             }
         }

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
@@ -76,7 +76,18 @@
 
         public void CheckDependency(string dependencyTypeFullName)
         {
-            _foundDependencies.Add(dependencyTypeFullName);
+            var matchedDependencies = _searchTree.GetAllMatchingNames(dependencyTypeFullName);
+            if (matchedDependencies.Any())
+            {
+                foreach (var match in matchedDependencies)
+                {
+                    _foundDependencies.Add(match);
+                }
+            }
+            else
+            {
+                _hasDependencyFromOutsideOfSearchTree = true;
+            }
         }
 
         public void CheckDependency(TypeReference dependency)

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingResult.cs
@@ -74,6 +74,11 @@
             }           
         }
 
+        public void CheckDependency(string dependencyTypeFullName)
+        {
+            _foundDependencies.Add(dependencyTypeFullName);
+        }
+
         public void CheckDependency(TypeReference dependency)
         {
             var matchedDependencies = _searchTree.GetAllMatchingNames(dependency);

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -396,6 +396,18 @@
         public void DependencySearch_VariableTuple_NotFound()
         {
             Utils.RunDependencyTest(typeof(VariableTuple), typeof(Tuple<int, double>), false, true);
-        }        
+        }
+
+        [Fact(DisplayName = "Finds a dependency StaticType in BaseCtorCall.")]
+        public void DependencySearch_BaseCtorCall_Found()
+        {
+            Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
+        }
+
+        [Fact(DisplayName = "Finds a dependency when a const string field accesses a type via full type name.")]
+        public void DependencySearch_ConstFieldString_Found()
+        {
+            Utils.RunDependencyTest(typeof(ConstStringFieldValue), typeof(Array), true, true);
+        }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -404,10 +404,16 @@
             Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
         }
 
-        [Fact(DisplayName = "Finds a dependency when a const string field accesses a type via full type name.")]
+        [Fact(DisplayName = "Finds a dependency Array in ConstStringFieldValue.")]
         public void DependencySearch_ConstFieldString_Found()
         {
             Utils.RunDependencyTest(typeof(ConstStringFieldValue), typeof(Array), true, true);
+        }
+
+        [Fact(DisplayName = "Does not find a dependency ArrayJagged in ConstStringFieldValue.")]
+        public void DependencySearch_ConstFieldString_NotFound()
+        {
+            Utils.RunDependencyTest(typeof(ConstStringFieldValue), typeof(ArrayJagged), false, true);
         }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -398,12 +398,6 @@
             Utils.RunDependencyTest(typeof(VariableTuple), typeof(Tuple<int, double>), false, true);
         }
 
-        [Fact(DisplayName = "Finds a dependency StaticType in BaseCtorCall.")]
-        public void DependencySearch_BaseCtorCall_Found()
-        {
-            Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
-        }
-
         [Fact(DisplayName = "Finds a dependency Array in ConstStringFieldValue.")]
         public void DependencySearch_ConstFieldString_Found()
         {

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/ConstStringFieldValue.cs
@@ -1,0 +1,9 @@
+﻿namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+{
+    public class ConstStringFieldValue
+    {
+#pragma warning disable 219
+        private const string FullTypeName = "NetArchTest.TestStructure.Dependencies.Search.DependencyType.Array";
+#pragma warning restore 219
+    }
+}


### PR DESCRIPTION
Here the final PR (based on #79) which uses the search tree to check for the depenency in string const fields. I was not able to use the `_cachedAnswersFromSearchTree` as I don't exactly know how to impl. a GetNode() for a string, which might be a type, namespace, generic or at least nothing of that. In such a case a simple string comparison might be better, but I had no idea how to integrate it into you search tree. Hope the current version fits to your idea of the search tree pattern, otherwise please let me know how to improve that.

> The version <=**1.2.6** has checked const string values. This is missing in the new dependency implementation and has been fixed by this commit. Test has also been added.