### PR TITLE
add tests for complex generic interface scenario

### DIFF
--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -1,4 +1,6 @@
-﻿namespace NetArchTest.Rules.UnitTests
+﻿using NetArchTest.TestStructure.Dependencies.Search.DependencyLocation;
+
+namespace NetArchTest.Rules.UnitTests
 {
     using System;
     using System.Linq;
@@ -279,6 +281,36 @@
                 .ImplementInterface(typeof(IExample)).GetResult();
 
             Assert.True(result.IsSuccessful);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they implement a specialized generic interface.")]
+        public void ImplementSpecializedGenericInterface_MatchesFound_ClassesSelected()
+        {
+	        var predicateList = Types
+		        .InAssembly(Assembly.GetAssembly(typeof(IGenericInterface<,>)))
+		        .That()
+		        .AreClasses()
+		        .And()
+		        .ImplementInterface(typeof(IGenericInterface<,>));
+
+	        var typesImplementingGenericInterface = predicateList.GetTypes();
+	        Assert.Collection(typesImplementingGenericInterface,
+		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
+		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type),
+		        type => Assert.Equal(typeof(ImplementedGenericInterface), type));
+
+            var conditionList = predicateList
+		        .Should()
+		        .ImplementInterface(typeof(ISpecializedGenericInterface1<,,>)).Or().ImplementInterface(typeof(ISpecializedGenericInterface2<,,>));
+
+	        var types = conditionList.GetTypes();
+	        Assert.Collection(types,
+		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
+		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type));
+
+            var result = conditionList.GetResult();
+            Assert.True(!result.IsSuccessful);
+            Assert.Single(result.FailingTypes, type => type == typeof(ImplementedGenericInterface));
         }
 
         [Fact(DisplayName = "Types can be selected if they do not implement an interface.")]

--- a/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionTests.cs
@@ -295,9 +295,10 @@ namespace NetArchTest.Rules.UnitTests
 
 	        var typesImplementingGenericInterface = predicateList.GetTypes();
 	        Assert.Collection(typesImplementingGenericInterface,
-		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
-		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type),
-		        type => Assert.Equal(typeof(ImplementedGenericInterface), type));
+		        type => Assert.Equal(typeof(ImplementedGenericInterface), type),
+
+                type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
+		        type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type));
 
             var conditionList = predicateList
 		        .Should()

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -1,4 +1,5 @@
-﻿using NetArchTest.TestStructure.NameMatching.Namespace3.A;
+﻿using NetArchTest.TestStructure.Dependencies.Search.DependencyLocation;
+using NetArchTest.TestStructure.NameMatching.Namespace3.A;
 using NetArchTest.TestStructure.NameMatching.Namespace3.B;
 
 namespace NetArchTest.Rules.UnitTests
@@ -337,6 +338,22 @@ namespace NetArchTest.Rules.UnitTests
 
             Assert.Single(result); // One type found
             Assert.Contains<Type>(typeof(ImplementsExampleInterface), result);
+        }
+
+        [Fact(DisplayName = "Types can be selected if they implement a generic interface.")]
+        public void ImplementGenericInterface_MatchesFound_ClassesSelected()
+        {
+	        var result = Types.InAssembly(Assembly.GetAssembly(typeof(IGenericInterface<,>)))
+		        .That()
+		        .AreClasses()
+		        .And()
+		        .ImplementInterface(typeof(IGenericInterface<,>))
+		        .GetTypes();
+
+            Assert.Collection(result,
+	            type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
+	            type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type),
+	            type => Assert.Equal(typeof(ImplementedGenericInterface), type));
         }
 
         [Fact(DisplayName = "Types can be selected if they do not implement an interface.")]

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -351,9 +351,9 @@ namespace NetArchTest.Rules.UnitTests
 		        .GetTypes();
 
             Assert.Collection(result,
+	            type => Assert.Equal(typeof(ImplementedGenericInterface), type),
 	            type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface1), type),
-	            type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type),
-	            type => Assert.Equal(typeof(ImplementedGenericInterface), type));
+	            type => Assert.Equal(typeof(ImplementedSpecializedGenericInterface2), type));
         }
 
         [Fact(DisplayName = "Types can be selected if they do not implement an interface.")]

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/IGenericInterface.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/IGenericInterface.cs
@@ -7,4 +7,11 @@ namespace NetArchTest.TestStructure.Dependencies.Examples
     interface IGenericInterface<T>
     {
     }
+
+    interface IGenericInterface<T1, T2>
+        where T1 : IEquatable<T1>
+        where T2 : IEnumerable<T1>
+    {
+
+    }
 }

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ISpecializedGenericInterface1.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ISpecializedGenericInterface1.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NetArchTest.TestStructure.Dependencies.Examples
+{
+	interface ISpecializedGenericInterface1<T1, T2, T3> : IGenericInterface<T1, T2>
+		where T1 : IEquatable<T1>
+		where T2 : IEnumerable<T1>
+	{
+
+	}
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/ISpecializedGenericInterface2.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/ISpecializedGenericInterface2.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NetArchTest.TestStructure.Dependencies.Examples
+{
+	interface ISpecializedGenericInterface2<T1, T2, T3> : IGenericInterface<T1, T2>
+		where T1 : IEquatable<T1>
+		where T2 : IEnumerable<T1>
+	{
+
+	}
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedGenericInterface.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedGenericInterface.cs
@@ -1,0 +1,9 @@
+﻿using NetArchTest.TestStructure.Dependencies.Examples;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
+{
+	class ImplementedGenericInterface : IGenericInterface<float, float[]>
+	{
+
+	}
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedSpecializedGenericInterface1.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedSpecializedGenericInterface1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NetArchTest.TestStructure.Dependencies.Examples;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
+{
+	class ImplementedSpecializedGenericInterface1 : ISpecializedGenericInterface1<int, int[], Guid>
+	{
+
+	}
+}

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedSpecializedGenericInterface2.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyLocation/ImplementedSpecializedGenericInterface2.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NetArchTest.TestStructure.Dependencies.Examples;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyLocation
+{
+	class ImplementedSpecializedGenericInterface2 : ISpecializedGenericInterface2<string, string[], Guid>
+	{
+
+	}
+}


### PR DESCRIPTION
I thought there might be a bug in the library because the following test failed on my machine...

``` csharp
[Fact]
public void AllModuleCommandResponseObjectsImplementDataContract()
{
    // Verify.That is my own helper method
    // it throws an exception with a pretty message listing all offending types from a ConditionList
    Verify.That(Types.InCurrentDomain().That().AreClasses().And().ImplementInterface(typeof(IModuleCommandResponse<,>))
        .Should()
        .ImplementInterface(typeof(IModuleCommandResponseFromCreatingEntity<,>))
        .Or().ImplementInterface(typeof(IModuleCommandResponseFromUpdatingEntity<,>)));
}
```

... but turns out it is just an issue with the Resharper test runner I am using.  No idea why.  The test passes when I use Visual Studio's test runner.  Perhaps these tests I wrote up are still useful to add to the main branch though?  If not, feel free to reject and close the PR.