### PR TITLE
fix: consider types referenced by non compiler generated fields inside ctor base calls

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -220,6 +220,9 @@
                                 }
                             }
                             break;
+                        case FieldReference fieldReference:
+                            CheckTypeReference(fieldReference.DeclaringType);
+                            break;
                         case MethodReference methodReference:
                             CheckTypeReference( methodReference.DeclaringType);
                             break;

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -221,7 +221,10 @@
                             }
                             break;
                         case FieldReference fieldReference:
-                            CheckTypeReference(fieldReference.DeclaringType);
+                            if (!fieldReference.Resolve().CustomAttributes.IsCompilerGenerated())
+                            {
+                                CheckTypeReference(fieldReference.DeclaringType);
+                            }
                             break;
                         case MethodReference methodReference:
                             CheckTypeReference( methodReference.DeclaringType);

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using Mono.Cecil;
     using System.Runtime.CompilerServices;
+    using Mono.Collections.Generic;
 
     /// <summary>
     /// Extensions for the <see cref="TypeDefinition"/> class.
@@ -107,7 +108,12 @@
 
         public static bool IsCompilerGenerated(this TypeDefinition typeDefinition)
         {
-            return typeDefinition.CustomAttributes.Any(x => x?.AttributeType?.FullName == typeof(CompilerGeneratedAttribute).FullName);
+            return typeDefinition.CustomAttributes.IsCompilerGenerated();
+        }
+
+        public static bool IsCompilerGenerated(this Collection<CustomAttribute> customAttributes)
+        {
+            return customAttributes.Any(x => x?.AttributeType?.FullName == typeof(CompilerGeneratedAttribute).FullName);
         }
 
         /// <summary>

--- a/src/NetArchTest.Rules/NetArchTest.Rules.xml
+++ b/src/NetArchTest.Rules/NetArchTest.Rules.xml
@@ -1177,14 +1177,14 @@
             Initializes a new instance of the <see cref="T:NetArchTest.Rules.Predicates"/> class.
             </summary>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.HaveName(System.String)">
+        <member name="M:NetArchTest.Rules.Predicates.HaveName(System.String[])">
             <summary>
             Selects types that have a specific name.
             </summary>
             <param name="name">The name of the class to match against.</param>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.DoNotHaveName(System.String)">
+        <member name="M:NetArchTest.Rules.Predicates.DoNotHaveName(System.String[])">
             <summary>
             Selects types that do not have a particular name.
             </summary>
@@ -1205,7 +1205,7 @@
             <param name="pattern">The regular expression pattern to match against.</param>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.HaveNameStartingWith(System.String)">
+        <member name="M:NetArchTest.Rules.Predicates.HaveNameStartingWith(System.String[])">
             <summary>
             Selects types whose names start with the specified text.
             </summary>
@@ -1220,7 +1220,7 @@
             <param name="comparer">The string comparer.</param>
             <returns>An updated set of predicates that can be applied to a list of types.</returns>
         </member>
-        <member name="M:NetArchTest.Rules.Predicates.DoNotHaveNameStartingWith(System.String)">
+        <member name="M:NetArchTest.Rules.Predicates.DoNotHaveNameStartingWith(System.String[])">
             <summary>
             Selects types whose names do not start with the specified text.
             </summary>

--- a/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/DependencySearch/DependencyTypeTests.cs
@@ -396,6 +396,12 @@
         public void DependencySearch_VariableTuple_NotFound()
         {
             Utils.RunDependencyTest(typeof(VariableTuple), typeof(Tuple<int, double>), false, true);
-        }        
+        }
+
+        [Fact(DisplayName = "Finds a dependency StaticType in BaseCtorCall.")]
+        public void DependencySearch_BaseCtorCall_Found()
+        {
+            Utils.RunDependencyTest(typeof(BaseCtorCall), typeof(StaticType), true, true);
+        }
     }
 }

--- a/test/NetArchTest.TestStructure/Dependencies/Examples/BaseCtorCall.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Examples/BaseCtorCall.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+﻿namespace NetArchTest.TestStructure.Dependencies.Examples
 {
     public struct Id
     {

--- a/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/Search/DependencyType/BaseCtorCall.cs
@@ -1,0 +1,30 @@
+﻿using System;
+
+namespace NetArchTest.TestStructure.Dependencies.Search.DependencyType
+{
+    public struct Id
+    {
+    }
+
+    public static class StaticType
+    {
+        public static readonly Id SomeId;
+    }
+
+    public abstract class BaseCtorCallBase
+    {
+#pragma warning disable 219
+        protected BaseCtorCallBase(params Id[] ids)
+        {
+        }
+#pragma warning restore 219
+    }
+
+    public class BaseCtorCall : BaseCtorCallBase
+    {
+        public BaseCtorCall() :
+            base(StaticType.SomeId)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Now all tests are past. The reason why [PR 85](https://github.com/BenMorris/NetArchTest/pull/85) has test failures was because the type created for the new test was not part of the examples namespace. The second reason was, that compiler generated fields don't need to be considered.

Now all tests passed locally. 