### PR TITLE
correction Of #86 and #85

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -225,13 +225,16 @@
                             }
                             break;
                         case FieldReference fieldReference:
-                            if (!fieldReference.Resolve().CustomAttributes.IsCompilerGenerated())
+                            if (fieldReference.DeclaringType != _typeToCheck)
                             {
                                 CheckTypeReference(fieldReference.DeclaringType);
                             }
                             break;
                         case MethodReference methodReference:
-                            CheckTypeReference( methodReference.DeclaringType);
+                            if (methodReference.DeclaringType != _typeToCheck)
+                            {
+                                CheckTypeReference(methodReference.DeclaringType);
+                            }
                             break;
                     }
                 }

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -108,12 +108,7 @@
 
         public static bool IsCompilerGenerated(this TypeDefinition typeDefinition)
         {
-            return typeDefinition.CustomAttributes.IsCompilerGenerated();
-        }
-
-        public static bool IsCompilerGenerated(this Collection<CustomAttribute> customAttributes)
-        {
-            return customAttributes.Any(x => x?.AttributeType?.FullName == typeof(CompilerGeneratedAttribute).FullName);
+            return typeDefinition.CustomAttributes.Any(x => x?.AttributeType?.FullName == typeof(CompilerGeneratedAttribute).FullName);
         }
 
         /// <summary>


### PR DESCRIPTION
I have a look at PR #86, which has a very misleading description. The problem which #86 solves does not have anything to do with base calls or compiler-generated code. The problem was not checking a type that contains a static field. Fixing that problem revealed (by some failing test in #85) another problem that is quite philosophical: if a type has a dependency on itself... The answer to that question from dependency search was not consistent, sometimes it had, sometimes it had not. After this PR answer should always be that the type does not have a dependency on itself. Not because it is true or not, but because I do not see any useful scenario from the perspective of this library where finding dependency on itself would matter.
 