### PR TITLE
correction Of #82

### DIFF
--- a/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
+++ b/src/NetArchTest.Rules/Dependencies/DependencySearch.cs
@@ -20,7 +20,7 @@
         /// <returns>A list of found types.</returns>
         public IReadOnlyList<TypeDefinition> FindTypesThatHaveDependencyOnAny(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {  
-            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.HaveDependencyOnAny, dependencies);           
+            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.HaveDependencyOnAny, dependencies, true);           
         }
 
         /// <summary>
@@ -31,7 +31,7 @@
         /// <returns>A list of found types.</returns>
         public IReadOnlyList<TypeDefinition> FindTypesThatHaveDependencyOnAll(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {  
-            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.HaveDependencyOnAll, dependencies);         
+            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.HaveDependencyOnAll, dependencies, true);         
         }
 
         /// <summary>
@@ -42,7 +42,7 @@
         /// <returns>A list of found types.</returns>
         public IReadOnlyList<TypeDefinition> FindTypesThatOnlyHaveDependenciesOnAnyOrNone(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {           
-            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAnyOrNone, dependencies);
+            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAnyOrNone, dependencies, false);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@
         /// <returns>A list of found types.</returns>
         public IReadOnlyList<TypeDefinition> FindTypesThatOnlyHaveDependenciesOnAny(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {
-            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAny, dependencies);
+            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAny, dependencies, false);
         }
 
         /// <summary>
@@ -64,17 +64,17 @@
         /// <returns>A list of found types.</returns>
         public IReadOnlyList<TypeDefinition> FindTypesThatOnlyOnlyHaveDependenciesOnAll(IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies)
         {
-            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAll, dependencies);
+            return FindTypes(input, TypeDefinitionCheckingResult.SearchType.OnlyHaveDependenciesOnAll, dependencies, false);
         }
 
-        private List<TypeDefinition> FindTypes(IEnumerable<TypeDefinition> input, TypeDefinitionCheckingResult.SearchType searchType, IEnumerable<string> dependencies)
+        private List<TypeDefinition> FindTypes(IEnumerable<TypeDefinition> input, TypeDefinitionCheckingResult.SearchType searchType, IEnumerable<string> dependencies, bool serachForDependencyInFieldConstant)
         {
             var output = new List<TypeDefinition>();
             var searchTree = new CachedNamespaceTree(dependencies);
 
             foreach (var type in input)
             {
-                var context = new TypeDefinitionCheckingContext(type, searchType, searchTree);
+                var context = new TypeDefinitionCheckingContext(type, searchType, searchTree, serachForDependencyInFieldConstant);
                 if (context.IsTypeFound())
                 {
                     output.Add(type);

--- a/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
+++ b/src/NetArchTest.Rules/Dependencies/TypeDefinitionCheckingContext.cs
@@ -9,13 +9,14 @@
     internal class TypeDefinitionCheckingContext
     {
         private readonly TypeDefinition _typeToCheck;
-        private readonly TypeDefinitionCheckingResult _result;
-        
+        private readonly TypeDefinitionCheckingResult _result;        
+        private readonly bool _serachForDependencyInFieldConstant;
 
-        public TypeDefinitionCheckingContext(TypeDefinition typeToCheck, TypeDefinitionCheckingResult.SearchType searchType, ISearchTree searchTree)
+        public TypeDefinitionCheckingContext(TypeDefinition typeToCheck, TypeDefinitionCheckingResult.SearchType searchType, ISearchTree searchTree, bool serachForDependencyInFieldConstant = false)
         {
             _typeToCheck = typeToCheck;
-            _result = new TypeDefinitionCheckingResult(searchType, searchTree);         
+            _result = new TypeDefinitionCheckingResult(searchType, searchTree);
+            _serachForDependencyInFieldConstant = serachForDependencyInFieldConstant;
         }
 
         public bool IsTypeFound()
@@ -96,7 +97,7 @@
                 {
                     CheckCustomAttributes(field);
                     CheckTypeReference(field.FieldType);
-                    if (field.HasConstant && field.FieldType.FullName == typeof(string).FullName)
+                    if (_serachForDependencyInFieldConstant && field.HasConstant && field.FieldType.FullName == typeof(string).FullName)
                     {
                         _result.CheckDependency(field.Constant.ToString());
                     }

--- a/test/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
+++ b/test/NetArchTest.TestStructure/Dependencies/TypeOfSearch/Classes.cs
@@ -9,6 +9,8 @@
 
     public class Class_A
     {
+        string stringField = "I am not a dependency!";
+
         public static void LetUsCreateSomeAnonymousTypes()
         {
             var numbers = Enumerable.Range(0, 1);


### PR DESCRIPTION
The simplest solution for #82 would be just always checking string literals for HaveDependencyOnAny and HaveDependencyOnAll, and never for OnlyHaveDependenciesOnAnyOrNone, OnlyHaveDependenciesOnAny, OnlyHaveDependenciesOnAll, HaveDependencyOtherThan.

In the future, it would be nice to give the user possibility to decide if he or she wants to look for dependencies in string literals, but for now, this will do the job.

The small change in test class shows problems created by PR #82, and PR #86. All test will pass after merging this PR and #94.