### PR TITLE
correction of #98

### DIFF
--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -119,7 +119,7 @@
         /// </remarks>
         public static string GetNamespace(this TypeDefinition typeDefinition)
         {
-            if ((typeDefinition.IsNestedPrivate) || (typeDefinition.IsNestedPublic))
+            if ((typeDefinition.IsNested))
             {
                 return typeDefinition.DeclaringType.FullName;
             }


### PR DESCRIPTION
#98 