### PR TITLE
Updated tests to net6 and prevented custom rules evaluating more than…

### DIFF
--- a/samples/NetArchTest.SampleRules/NetArchTest.SampleRules.csproj
+++ b/samples/NetArchTest.SampleRules/NetArchTest.SampleRules.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NetArchTest.Rules/ConditionList.cs
+++ b/src/NetArchTest.Rules/ConditionList.cs
@@ -37,15 +37,19 @@
         public TestResult GetResult()
         {
             bool success;
+            IEnumerable<TypeDefinition> typeDefinitions;
+
             if (_should)
             {
                 // All the classes should meet the condition
-                success = (_sequence.Execute(_types).Count() == _types.Count());
+                typeDefinitions = _sequence.Execute(_types);
+                success = (typeDefinitions.Count() == _types.Count());
             }
             else
             {
                 // No classes should meet the condition
-                success = (!_sequence.Execute(_types).Any());
+                typeDefinitions = (_sequence.Execute(_types));
+                success = (!typeDefinitions.Any());
             }
 
             if (success)
@@ -53,9 +57,10 @@
                 return TestResult.Success();
             }
 
-            // If we've failed, get a collection of failing types so these can be reported in a failing test.
-            var failedTypes = _sequence.Execute(_types, selected: !_should).ToList();
-            return TestResult.Failure(failedTypes);
+            return TestResult.Failure(
+                _should 
+                    ? _types.Except(typeDefinitions).ToList()
+                    : typeDefinitions.Distinct().ToList());
         }
 
         /// <summary>

--- a/test/NetArchTest.Rules.UnitTests/CustomRuleExample.cs
+++ b/test/NetArchTest.Rules.UnitTests/CustomRuleExample.cs
@@ -9,8 +9,13 @@
     public class CustomRuleExample : ICustomRule
     {
         /// <summary> Used by tests to indicate whether the test method has been called. </summary>
-        public bool TestMethodCalled = false;
-
+        public bool TestMethodCalled => _timesCalled > 0;
+        
+        /// <summary>The number of times the meetsrule method has been called.</summary>
+        public int TimesTimesCalled => _timesCalled;
+        
+        private int _timesCalled = 0;
+        
         /// <summary> The delegate that is used for the rule - this allows the test to define the custom rule. </summary>
         private Func<TypeDefinition, bool> _test;
 
@@ -21,7 +26,7 @@
 
         public bool MeetsRule(TypeDefinition type)
         {
-            TestMethodCalled = true;
+            _timesCalled++;
             return _test(type);
         }
     }

--- a/test/NetArchTest.Rules.UnitTests/NetArchTest.Rules.UnitTests.csproj
+++ b/test/NetArchTest.Rules.UnitTests/NetArchTest.Rules.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateTests.cs
@@ -1080,5 +1080,21 @@ namespace NetArchTest.Rules.UnitTests
             // The custom rule was executed at least once
             Assert.True(rule.TestMethodCalled);
         }
+        
+        [Fact(DisplayName = "Custom rule that returns false doesnt evaluate twice.")]
+        public void GetResult_Doesnt_Evaluate_Twice()
+        {
+            var customRule = new CustomRuleExample(_ => false);
+
+            var t = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .HaveName("ClassA1")
+                .Should()
+                .MeetCustomRule(customRule)
+                .GetResult();
+            
+            Assert.True(customRule.TimesTimesCalled == 1);
+        }
     }
 }


### PR DESCRIPTION
… once if the custom rule returns false.

While writing output to the xunit console I noticed that if a custom rule failed, the output to the console was doubled up. This change stores the TypeDefinition results that's returned from calling execute on the sequence and then reuses it in a failure scenario.

I've ran all the tests and it appears to look ok.

The tests have also been updated from netcore3 to net6 as it's the latest LTS version.