### PR TITLE
Refactoring: Nesting

### DIFF
--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -124,227 +124,128 @@ namespace NetArchTest.Rules
         };
 
         /// <summary> Function for finding interfaces. </summary>
-        internal static FunctionDelegate<bool> BeInterface = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeInterface = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsInterface);
-            }
-            else
-            {
-                return input.Where(c => !c.IsInterface);
-            }
+            return input.Where(c => c.IsInterface == condition);
         };
 
         /// <summary> Function for finding static classes. </summary>
-        internal static FunctionDelegate<bool> BeStatic = delegate(IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeStatic = delegate(IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-	        if (condition)
-	        {
-		        return input.Where(ClassIsStatic);
-	        }
-	        else
-	        {
-		        return input.Where(c => !ClassIsStatic(c));
-	        }
+            return input.Where(c => ClassIsStatic(c) == condition);
 
-	        bool ClassIsStatic(TypeDefinition c) => c.IsAbstract && c.IsSealed && !c.IsInterface && !c.GetConstructors().Any(m => m.IsPublic);
+            bool ClassIsStatic(TypeDefinition c) => 
+                c.IsAbstract 
+                && c.IsSealed 
+                && !c.IsInterface 
+                && !c.GetConstructors().Any(m => m.IsPublic);
         };
 
         /// <summary> Function for finding types with generic parameters. </summary>
-        internal static FunctionDelegate<bool> BeGeneric = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeGeneric = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.HasGenericParameters);
-            }
-            else
-            {
-                return input.Where(c => !c.HasGenericParameters);
-            }
+            return input.Where(c => c.HasGenericParameters == condition);
         };
 
 
         /// <summary> Function for finding nested classes. </summary>
-        internal static FunctionDelegate<bool> BeNested = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeNested = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsNested);
-            }
-            else
-            {
-                return input.Where(c => !c.IsNested);
-            }
+            return input.Where(c => c.IsNested == condition);
         };
 
         /// <summary> Function for finding nested public classes. </summary>
-        internal static FunctionDelegate<bool> BeNestedPublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeNestedPublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsNestedPublic);
-            }
-            else
-            {
-                return input.Where(c => !c.IsNestedPublic);
-            }
+            return input.Where(c => c.IsNestedPublic == condition);
         };
 
         /// <summary> Function for finding nested private classes. </summary>
-        internal static FunctionDelegate<bool> BeNestedPrivate = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeNestedPrivate = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsNestedPrivate);
-            }
-            else
-            {
-                return input.Where(c => !c.IsNestedPrivate);
-            }
+            return input.Where(c => c.IsNestedPrivate == condition);
         };
 
-
         /// <summary> Function for finding public classes. </summary>
-        internal static FunctionDelegate<bool> BePublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BePublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsNested ? c.IsNestedPublic : c.IsPublic);
-            }
-            else
-            {
-                return input.Where(c => c.IsNested ? !c.IsNestedPublic : c.IsNotPublic);
-            }
+            return condition 
+                ? input.Where(c => c.IsNested ? c.IsNestedPublic : c.IsPublic)
+                : input.Where(c => c.IsNested ? !c.IsNestedPublic : c.IsNotPublic);
         };
 
         /// <summary> Function for finding sealed classes. </summary>
-        internal static FunctionDelegate<bool> BeSealed = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeSealed = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsSealed);
-            }
-            else
-            {
-                return input.Where(c => !c.IsSealed);
-            }
+            return input.Where(c => c.IsSealed == condition);
         };
 
         /// <summary> Function for finding immutable classes. </summary>
-        internal static FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsImmutable());
-            }
-            else
-            {
-                return input.Where(c => !c.IsImmutable());
-            }
+            return input.Where(c => c.IsImmutable() == condition);
         };
 
         /// <summary> Function for finding nullable classes. </summary>
-        internal static FunctionDelegate<bool> HasNullableMembers = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+        internal static readonly FunctionDelegate<bool> HasNullableMembers = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.HasNullableMembers());
-            }
-            else
-            {
-                return input.Where(c => !c.HasNullableMembers());
-            }
+            return input.Where(c => c.HasNullableMembers() == condition);
         };
 
         /// <summary> Function for finding types in a particular namespace. </summary>
-        internal static FunctionDelegate<string> ResideInNamespace = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
+        internal static readonly FunctionDelegate<string> ResideInNamespace = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                return input.Where(c => !c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase));
-            }
+            return input.Where(c => 
+                c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase) == condition);
         };
 
         /// <summary> Function for matching a type name using a regular expression. </summary>
-        internal static FunctionDelegate<string> ResideInNamespaceMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
+        internal static readonly FunctionDelegate<string> ResideInNamespaceMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
         {
-            Regex r = new Regex(pattern, RegexOptions.IgnoreCase);
-            if (condition)
-            {
-                return input.Where(c => r.Match(c.GetNamespace()).Success);
-            }
-            else
-            {
-                return input.Where(c => !r.Match(c.GetNamespace()).Success);
-            }
+            var r = new Regex(pattern, RegexOptions.IgnoreCase);
+            
+            return input.Where(c => r.Match(c.GetNamespace()).Success == condition);
         };
 
         /// <summary> Function for finding types that have a dependency on any of the supplied types. </summary>
-        internal static FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
         {
             // Get the types that contain the dependencies
             var search = new DependencySearch();
             var results = search.FindTypesThatHaveDependencyOnAny(input, dependencies);
 
-            if (condition)
-            {
-                return results;
-            }
-            else
-            {
-                return input.Where(t => !results.Contains(t));
-            }
+            return condition
+                ? results
+                : input.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding types that have a dependency on all of the supplied types. </summary>
-        internal static FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
         {
             // Get the types that contain the dependencies
             var search = new DependencySearch();
             var results = search.FindTypesThatHaveDependencyOnAll(input, dependencies);
 
-            if (condition)
-            {
-                return results;
-            }
-            else
-            {
-                return input.Where(t => !results.Contains(t));
-            }
+            return condition
+                ? results
+                : input.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding types that have a dependency on type other than one of the supplied types.</summary>
-        internal static FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+        internal static readonly FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
         {            
             var search = new DependencySearch();
             var results = search.FindTypesThatOnlyHaveDependenciesOnAnyOrNone(input, dependencies);
 
-            if (condition)
-            {
-                return results;
-            }
-            else
-            {
-                return input.Where(t => !results.Contains(t));
-            }
+            return condition
+                ? results
+                : input.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding public classes. </summary>
-        internal static FunctionDelegate<ICustomRule> MeetCustomRule = delegate (IEnumerable<TypeDefinition> input, ICustomRule rule, bool condition)
+        internal static readonly FunctionDelegate<ICustomRule> MeetCustomRule = delegate (IEnumerable<TypeDefinition> input, ICustomRule rule, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(t => rule.MeetsRule(t));
-            }
-            else
-            {
-                return input.Where(t => !rule.MeetsRule(t));
-            }
+            return input.Where(t => rule.MeetsRule(t) == condition);
         };
     }
 }

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -28,108 +28,67 @@ namespace NetArchTest.Rules
         internal delegate IEnumerable<TypeDefinition> FunctionDelegate<T>(IEnumerable<TypeDefinition> input, T arg, bool condition);
 
         /// <summary> Function for finding a specific type name. </summary>
-        internal static FunctionDelegate<string> HaveName = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
+        internal static readonly FunctionDelegate<string> HaveName = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
-            }
-            else
-            {
-                return input.Where(c => !c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
-            }
+            return input.Where(c => 
+                c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) == condition);
         };
 
         /// <summary> Function for matching a type name using a regular expression. </summary>
-        internal static FunctionDelegate<string> HaveNameMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
+        internal static readonly FunctionDelegate<string> HaveNameMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
         {
-            Regex r = new Regex(pattern, RegexOptions.IgnoreCase);
-            if (condition)
-            {
-                return input.Where(c => r.Match(c.Name).Success);
-            }
-            else
-            {
-                return input.Where(c => !r.Match(c.Name).Success);
-            }
+            var r = new Regex(pattern, RegexOptions.IgnoreCase);
+            
+            return input.Where(c => r.Match(c.Name).Success == condition);
         };
 
         /// <summary> Function for matching the start of a type name. </summary>
-        internal static FunctionDelegate<string> HaveNameStartingWith = MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison.InvariantCultureIgnoreCase);
+        internal static readonly FunctionDelegate<string> HaveNameStartingWith = MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison.InvariantCultureIgnoreCase);
 
         internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison comparer) => delegate (IEnumerable<TypeDefinition> input, string start, bool condition)
         {
-	        if (condition)
-	        {
-		        return input.Where(c => c.Name.StartsWith(start, comparer));
-	        }
-		    else
-	        {
-		        return input.Where(c => !c.Name.StartsWith(start, comparer));
-	        }
+            return input.Where(c => c.Name.StartsWith(start, comparer) == condition);
         };
 
         /// <summary> Function for matching the end of a type name. </summary>
-        internal static FunctionDelegate<string> HaveNameEndingWith = MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison.InvariantCultureIgnoreCase);
+        internal static readonly FunctionDelegate<string> HaveNameEndingWith = MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison.InvariantCultureIgnoreCase);
 
         internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison comparer) => delegate (IEnumerable<TypeDefinition> input, string end, bool condition)
         {
-	        if (condition)
-	        {
-		        return input.Where(c => c.Name.EndsWith(end, comparer));
-	        }
-	        else
-	        {
-		        return input.Where(c => !c.Name.EndsWith(end, comparer));
-	        }
+            return input.Where(c => c.Name.EndsWith(end, comparer) == condition);
         };
 
         /// <summary> Function for finding classes with a particular custom attribute. </summary>
-        internal static FunctionDelegate<Type> HaveCustomAttribute = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
+        internal static readonly FunctionDelegate<Type> HaveCustomAttribute = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.CustomAttributes.Any(a => attribute.FullName.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase)));
-            }
-            else
-            {
-                return input.Where(c => !c.CustomAttributes.Any(a => attribute.FullName.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase)));
-            }
+            return input.Where(c => 
+                c.CustomAttributes.Any(a => 
+                    attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
+                == condition);
         };
 
         /// <summary> Function for finding classes decorated with a particular custom attribute or derived one</summary>
-        internal static FunctionDelegate<Type> HaveCustomAttributeOrInherit = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
+        internal static readonly FunctionDelegate<Type> HaveCustomAttributeOrInherit = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
         {
-            // Convert the incoming type to a definition
             var target = attribute.ToTypeDefinition();
-            if (condition)
-            {
-                return input.Where(c => c.CustomAttributes.Any(a => a.AttributeType.Resolve().IsSubclassOf(target) || attribute.FullName.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase)));
-            }
-            else
-            {
-                return input.Where(c => !(c.CustomAttributes.Any(a => a.AttributeType.Resolve().IsSubclassOf(target) || attribute.FullName.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase))));
-            }
+
+            return input.Where(c => 
+                c.CustomAttributes.Any(a => 
+                    a.AttributeType.Resolve().IsSubclassOf(target) || (attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
+                ) == condition);
         };
 
 
         /// <summary> Function for finding classes that inherit from a particular type. </summary>
-        internal static FunctionDelegate<Type> Inherits = delegate (IEnumerable<TypeDefinition> input, Type type, bool condition)
+        internal static readonly FunctionDelegate<Type> Inherits = delegate (IEnumerable<TypeDefinition> input, Type type, bool condition)
         {
-            // Convert the incoming type to a definition
             var target = type.ToTypeDefinition();
-            if (condition)
-            {
-                return input.Where(c => c.IsSubclassOf(target));
-            }
-            else
-            {
-                return input.Where(c => !c.IsSubclassOf(target));
-            }
+
+            return input.Where(c => c.IsSubclassOf(target) == condition);
         };
 
         /// <summary> Function for finding classes that implement a particular interface. </summary>
-        internal static FunctionDelegate<Type> ImplementsInterface = delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
+        internal static readonly FunctionDelegate<Type> ImplementsInterface = delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
         {
             if (!typeInterface.IsInterface)
             {
@@ -146,41 +105,22 @@ namespace NetArchTest.Rules
                     found.Add(type);
                 }
             }
-
-            if (condition)
-            {
-                return found;
-            }
-            else
-            {
-                return input.Where(c => !found.Contains(c));
-            }
+            
+            return condition
+                ? found
+                : input.Where(c => !found.Contains(c));
         };
 
         /// <summary> Function for finding abstract classes. </summary>
-        internal static FunctionDelegate<bool> BeAbstract = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeAbstract = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsAbstract);
-            }
-            else
-            {
-                return input.Where(c => !c.IsAbstract);
-            }
+            return input.Where(c => c.IsAbstract == condition);
         };
 
         /// <summary> Function for finding classes. </summary>
-        internal static FunctionDelegate<bool> BeClass = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+        internal static readonly FunctionDelegate<bool> BeClass = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
         {
-            if (condition)
-            {
-                return input.Where(c => c.IsClass);
-            }
-            else
-            {
-                return input.Where(c => !c.IsClass);
-            }
+            return input.Where(c => c.IsClass == condition);
         };
 
         /// <summary> Function for finding interfaces. </summary>

--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -29,41 +29,17 @@
         /// <remarks>
         /// This method loads all the types and may throw dependency loading errors if the test project does not have a direct dependency on the type being loaded.
         /// </remarks>
-        public IReadOnlyList<Type> FailingTypes
-        {
-            get
-            {
-                if (_failingTypes != null)
-                {
-                    return _failingTypes.Select(t => t.ToType()).ToList();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+        public IReadOnlyList<Type> FailingTypes 
+            => _failingTypes?.Select(t => t.ToType()).ToList();
 
         /// <summary>
-        /// Gets a list of the type nmames that failed the test.
+        /// Gets a list of the type names that failed the test.
         /// </summary>
         /// <remarks>
         /// This is a "safer" way of getting a list of failed types as it does not load the types when enumerating the list. This can lead to dependency loading errors.
         /// </remarks>
         public IReadOnlyList<string> FailingTypeNames
-        {
-            get
-            {
-                if (_failingTypes != null)
-                {
-                    return _failingTypes.Select(t => t.FullName).ToList();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
+            => _failingTypes?.Select(t => t.FullName).ToList();
 
 
         /// <summary>
@@ -71,24 +47,20 @@
         /// </summary>
         /// <returns>Instance of <see cref="TestResult"/></returns>
         internal static TestResult Success()
-        {
-            return new TestResult
+            => new TestResult
             {
                 IsSuccessful = true
             };
-        }
 
         /// <summary>
         /// Creates a new instance of <see cref="TestResult"/> indicating a failed test.
         /// </summary>
         /// <returns>Instance of <see cref="TestResult"/></returns>
         internal static TestResult Failure(IReadOnlyList<TypeDefinition> failingTypes)
-        {
-            return new TestResult
+            => new TestResult
             {
                 IsSuccessful = false,
                 _failingTypes = failingTypes
             };
-        }
     }
 }


### PR DESCRIPTION
Some refactorings in the FunctionDelegates.cs and TestResults.cs.
Same logic, just shortened.
Mainly removing unnecessary nesting.

All Unit Tests executed successfully.

There is a bunch of other stuff that can be refactored.
If refactoring is desired in general, I could do that and break it down into multiple PRs.