### PR TITLE
Refactoring: Modifier Order & Access To Properties

### DIFF
--- a/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/FieldDefinitionExtensions.cs
@@ -8,7 +8,7 @@ namespace NetArchTest.Rules.Extensions
     /// <summary>
     /// Extensions for the <see cref="FieldDefinition"/> class.
     /// </summary>
-    static internal class FieldDefinitionExtensions
+    internal static class FieldDefinitionExtensions
     {
         /// <summary>
         /// Tests whether a field is readonly

--- a/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/PropertyDefinitionExtensions.cs
@@ -8,7 +8,7 @@ namespace NetArchTest.Rules.Extensions
     /// <summary>
     /// Extensions for the <see cref="PropertyDefinition"/> class.
     /// </summary>
-    static internal class PropertyDefinitionExtensions
+    internal static class PropertyDefinitionExtensions
     {
         /// <summary>
         /// Tests whether a property is readonly

--- a/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeDefinitionExtensions.cs
@@ -10,7 +10,7 @@
     /// <summary>
     /// Extensions for the <see cref="TypeDefinition"/> class.
     /// </summary>
-    static internal class TypeDefinitionExtensions
+    internal static class TypeDefinitionExtensions
     {
         /// <summary>
         /// Tests whether one class inherits from another.

--- a/src/NetArchTest.Rules/Extensions/TypeExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeExtensions.cs
@@ -8,7 +8,7 @@
     /// <summary>
     /// Extensions for the <see cref="Type"/> class.
     /// </summary>
-    static internal class TypeExtensions
+    internal static class TypeExtensions
     {
         /// <summary>
         /// Converts the value to a <see cref="TypeDefinition"/> instance.

--- a/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
+++ b/src/NetArchTest.Rules/Extensions/TypeReferenceExtensions.cs
@@ -5,7 +5,7 @@ namespace NetArchTest.Rules.Extensions
     using System.Collections.Generic;
     using Mono.Cecil;
 
-    static internal class TypeReferenceExtensions
+    internal static class TypeReferenceExtensions
     {
         /// <summary>
         /// Tests whether a Type is a non-nullable value type

--- a/src/NetArchTest.Rules/Policies/Policy.cs
+++ b/src/NetArchTest.Rules/Policies/Policy.cs
@@ -8,10 +8,10 @@
     public sealed class Policy
     {
         /// <summary> The simple name of the policy. </summary>
-        private string _name;
+        private readonly string _name;
 
         /// <summary> A detailed description of the policy. </summary>
-        private string _description;
+        private readonly string _description;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Policy"/> class.

--- a/src/NetArchTest.Rules/Policies/PolicyDefinition.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyDefinition.cs
@@ -28,12 +28,12 @@
         /// <summary>
         /// The simple name of the policy.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// A detailed description of the policy.
         /// </summary>
-        public string Description { get; private set; }
+        public string Description { get; }
 
         /// <summary>
         /// Adds a rule to the policy that can optionally be marked with a name and description.

--- a/src/NetArchTest.Rules/Policies/PolicyDefinition.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyDefinition.cs
@@ -10,10 +10,10 @@
     public sealed class PolicyDefinition
     {
         /// <summary> The function that defines the list of types to execute against each rule. </summary>
-        private Func<Types> _typesLocator;
+        private readonly Func<Types> _typesLocator;
 
         /// <summary> The list of tests that have been added to the policy. </summary>
-        private List<PolicyTest> _tests = new List<PolicyTest>();
+        private readonly List<PolicyTest> _tests = new List<PolicyTest>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolicyDefinition"/> class.

--- a/src/NetArchTest.Rules/Policies/PolicyResult.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyResult.cs
@@ -22,21 +22,21 @@
         /// <summary>
         /// Gets a flag indicating the success or failure of the test.
         /// </summary>
-        public bool IsSuccessful { get; private set; }
+        public bool IsSuccessful { get; }
 
         /// <summary>
         /// Gets a collection populated with a list of any types that failed the test.
         /// </summary>
-        public IEnumerable<Type> FailingTypes { get; private set; }
+        public IEnumerable<Type> FailingTypes { get; }
 
         /// <summary>
         /// Gets the simple name associated with the test.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets the detailed description associated with the test.
         /// </summary>
-        public string Description { get; private set; }
+        public string Description { get; }
     }
 }

--- a/src/NetArchTest.Rules/Policies/PolicyResults.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyResults.cs
@@ -22,27 +22,22 @@
         /// Gets whether or not the policy has any rule violations
         /// </summary>
         public bool HasViolations
-        {
-            get
-            {
-                return Results.Any(r => !r.IsSuccessful);
-            }
-        }
+            => Results.Any(r => !r.IsSuccessful);
 
         /// <summary>
         /// Gets the results of each rule that was added the policy.
         /// </summary>
-        public IReadOnlyList<PolicyResult> Results { get; private set; }
+        public IReadOnlyList<PolicyResult> Results { get; }
 
         /// <summary>
         /// Gets the simple name associated with the policy.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets the detailed description associated with the policy.
         /// </summary>
-        public string Description { get; private set; }
+        public string Description { get; }
 
     }
 }

--- a/src/NetArchTest.Rules/Policies/PolicyTest.cs
+++ b/src/NetArchTest.Rules/Policies/PolicyTest.cs
@@ -20,16 +20,16 @@
         /// <summary>
         /// The definition of the test expressed as a function.
         /// </summary>
-        internal Func<Types, ConditionList> Definition { get; private set; }
+        internal Func<Types, ConditionList> Definition { get; }
 
         /// <summary>
         /// Gets the simple name associated with the test.
         /// </summary>
-        internal string Name { get; private set; }
+        internal string Name { get; }
 
         /// <summary>
         /// Gets the detailed description associated with the test.
         /// </summary>
-        internal string Description { get; private set; }
+        internal string Description { get; }
     }
 }


### PR DESCRIPTION
Refactorings related to class / property / field access.

Changes:
- removed ununsed accessors
- fixed order of modifiers
- set fields readonly
- changed access to `FunctionCall`
  -  `internal` -> `private`

All Unit Tests executed successfully.

Independent, not related to #109 .

Please merge these PRs as soon as you can.
It's easier for me to start additional refactorings on top of these changes.