### PR TITLE
Refactoring: Multiple Enumeration & Style

### DIFF
--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -84,6 +84,8 @@ namespace NetArchTest.Rules
         /// <summary> Function for finding classes that implement a particular interface. </summary>
         internal static readonly FunctionDelegate<Type> ImplementsInterface = delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
         {
+            var typeDefinitions = input.ToList();
+            
             if (!typeInterface.IsInterface)
             {
                 throw new ArgumentException($"The type {typeInterface.FullName} is not an interface.");
@@ -92,7 +94,7 @@ namespace NetArchTest.Rules
             var target = typeInterface.FullName;
             var found = new List<TypeDefinition>();
 
-            foreach (var type in input)
+            foreach (var type in typeDefinitions)
             {
                 if (type.Interfaces.Any(t => t.InterfaceType.Resolve().FullName.Equals(target, StringComparison.InvariantCultureIgnoreCase)))
                 {
@@ -102,7 +104,7 @@ namespace NetArchTest.Rules
             
             return condition
                 ? found
-                : input.Where(c => !found.Contains(c));
+                : typeDefinitions.Where(c => !found.Contains(c));
         };
 
         /// <summary> Function for finding abstract classes. </summary>
@@ -204,36 +206,42 @@ namespace NetArchTest.Rules
         /// <summary> Function for finding types that have a dependency on any of the supplied types. </summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
         {
+            var typeDefinitions = input.ToList();
+            
             // Get the types that contain the dependencies
             var search = new DependencySearch();
-            var results = search.FindTypesThatHaveDependencyOnAny(input, dependencies);
+            var results = search.FindTypesThatHaveDependencyOnAny(typeDefinitions, dependencies);
 
             return condition
                 ? results
-                : input.Where(t => !results.Contains(t));
+                : typeDefinitions.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding types that have a dependency on all of the supplied types. </summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
         {
+            var typeDefinitions = input.ToList();
+            
             // Get the types that contain the dependencies
             var search = new DependencySearch();
-            var results = search.FindTypesThatHaveDependencyOnAll(input, dependencies);
+            var results = search.FindTypesThatHaveDependencyOnAll(typeDefinitions, dependencies);
 
             return condition
                 ? results
-                : input.Where(t => !results.Contains(t));
+                : typeDefinitions.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding types that have a dependency on type other than one of the supplied types.</summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
-        {            
+        {
+            var typeDefinitions = input.ToList();
+            
             var search = new DependencySearch();
-            var results = search.FindTypesThatOnlyHaveDependenciesOnAnyOrNone(input, dependencies);
+            var results = search.FindTypesThatOnlyHaveDependenciesOnAnyOrNone(typeDefinitions, dependencies);
 
             return condition
                 ? results
-                : input.Where(t => !results.Contains(t));
+                : typeDefinitions.Where(t => !results.Contains(t));
         };
 
         /// <summary> Function for finding public classes. </summary>

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -10,12 +10,6 @@ namespace NetArchTest.Rules
     using NetArchTest.Rules.Extensions;
     using Mono.Cecil;
 
-    internal class StringAndComparisonStrategy
-    {
-		public string Value { get; }
-        public StringComparison Comparer { get; }
-    }
-
     /// <summary>
     /// Defines the various functions that can be applied to a collection of types.
     /// </summary>

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -222,7 +222,7 @@ namespace NetArchTest.Rules
         /// Function for finding sealed classes.
         /// </summary>
         internal static readonly FunctionDelegate<bool> BeSealed = 
-            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsSealed == condition);
             };
@@ -231,7 +231,7 @@ namespace NetArchTest.Rules
         /// Function for finding immutable classes.
         /// </summary>
         internal static readonly FunctionDelegate<bool> BeImmutable = 
-            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsImmutable() == condition);
             };
@@ -240,7 +240,7 @@ namespace NetArchTest.Rules
         /// Function for finding nullable classes.
         /// </summary>
         internal static readonly FunctionDelegate<bool> HasNullableMembers = 
-            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.HasNullableMembers() == condition);
             };

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -18,10 +18,14 @@ namespace NetArchTest.Rules
     /// </remarks>
     internal static class FunctionDelegates
     {
-        /// <summary> The base delegate type used by every function. </summary>
+        /// <summary>
+        /// The base delegate type used by every function.
+        /// </summary>
         internal delegate IEnumerable<TypeDefinition> FunctionDelegate<T>(IEnumerable<TypeDefinition> input, T arg, bool condition);
 
-        /// <summary> Function for finding a specific type name. </summary>
+        /// <summary>
+        /// Function for finding a specific type name.
+        /// </summary>
         internal static readonly FunctionDelegate<string> HaveName = 
             delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
             {
@@ -29,7 +33,9 @@ namespace NetArchTest.Rules
                     c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) == condition);
             };
 
-        /// <summary> Function for matching a type name using a regular expression. </summary>
+        /// <summary>
+        /// Function for matching a type name using a regular expression.
+        /// </summary>
         internal static readonly FunctionDelegate<string> HaveNameMatching = 
             delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
             {
@@ -38,7 +44,9 @@ namespace NetArchTest.Rules
                 return input.Where(c => r.Match(c.Name).Success == condition);
             };
 
-        /// <summary> Function for matching the start of a type name. </summary>
+        /// <summary>
+        /// Function for matching the start of a type name.
+        /// </summary>
         internal static readonly FunctionDelegate<string> HaveNameStartingWith = 
             MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison.InvariantCultureIgnoreCase);
 
@@ -48,7 +56,9 @@ namespace NetArchTest.Rules
                 return input.Where(c => c.Name.StartsWith(start, comparer) == condition);
             };
 
-        /// <summary> Function for matching the end of a type name. </summary>
+        /// <summary>
+        /// Function for matching the end of a type name.
+        /// </summary>
         internal static readonly FunctionDelegate<string> HaveNameEndingWith = 
             MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison.InvariantCultureIgnoreCase);
 
@@ -58,7 +68,9 @@ namespace NetArchTest.Rules
                 return input.Where(c => c.Name.EndsWith(end, comparer) == condition);
             };
 
-        /// <summary> Function for finding classes with a particular custom attribute. </summary>
+        /// <summary>
+        /// Function for finding classes with a particular custom attribute.
+        /// </summary>
         internal static readonly FunctionDelegate<Type> HaveCustomAttribute = 
             delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
             {
@@ -68,7 +80,9 @@ namespace NetArchTest.Rules
                     == condition);
             };
 
-        /// <summary> Function for finding classes decorated with a particular custom attribute or derived one</summary>
+        /// <summary>
+        /// Function for finding classes decorated with a particular custom attribute or derived one.
+        /// </summary>
         internal static readonly FunctionDelegate<Type> HaveCustomAttributeOrInherit = 
             delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
             {
@@ -82,7 +96,9 @@ namespace NetArchTest.Rules
             };
 
 
-        /// <summary> Function for finding classes that inherit from a particular type. </summary>
+        /// <summary>
+        /// Function for finding classes that inherit from a particular type.
+        /// </summary>
         internal static readonly FunctionDelegate<Type> Inherits = 
             delegate (IEnumerable<TypeDefinition> input, Type type, bool condition)
             {
@@ -91,7 +107,9 @@ namespace NetArchTest.Rules
                 return input.Where(c => c.IsSubclassOf(target) == condition);
             };
 
-        /// <summary> Function for finding classes that implement a particular interface. </summary>
+        /// <summary>
+        /// Function for finding classes that implement a particular interface.
+        /// </summary>
         internal static readonly FunctionDelegate<Type> ImplementsInterface = 
             delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
             {
@@ -112,28 +130,36 @@ namespace NetArchTest.Rules
                     : typeDefinitions.Except(matchingTypes);
             };
 
-        /// <summary> Function for finding abstract classes. </summary>
+        /// <summary>
+        /// Function for finding abstract classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeAbstract = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsAbstract == condition);
             };
 
-        /// <summary> Function for finding classes. </summary>
+        /// <summary>
+        /// Function for finding classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeClass = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsClass == condition);
             };
 
-        /// <summary> Function for finding interfaces. </summary>
+        /// <summary>
+        /// Function for finding interfaces.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeInterface = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsInterface == condition);
             };
 
-        /// <summary> Function for finding static classes. </summary>
+        /// <summary>
+        /// Function for finding static classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeStatic = 
             delegate(IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
@@ -146,7 +172,9 @@ namespace NetArchTest.Rules
                     && !c.GetConstructors().Any(m => m.IsPublic);
             };
 
-        /// <summary> Function for finding types with generic parameters. </summary>
+        /// <summary>
+        /// Function for finding types with generic parameters.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeGeneric = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
@@ -154,28 +182,36 @@ namespace NetArchTest.Rules
             };
 
 
-        /// <summary> Function for finding nested classes. </summary>
+        /// <summary>
+        /// Function for finding nested classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeNested = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsNested == condition);
             };
 
-        /// <summary> Function for finding nested public classes. </summary>
+        /// <summary>
+        /// Function for finding nested public classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeNestedPublic = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsNestedPublic == condition);
             };
 
-        /// <summary> Function for finding nested private classes. </summary>
+        /// <summary>
+        /// Function for finding nested private classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeNestedPrivate = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
                 return input.Where(c => c.IsNestedPrivate == condition);
             };
 
-        /// <summary> Function for finding public classes. </summary>
+        /// <summary>
+        /// Function for finding public classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BePublic = 
             delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
             {
@@ -184,28 +220,36 @@ namespace NetArchTest.Rules
                     : input.Where(c => c.IsNested ? !c.IsNestedPublic : c.IsNotPublic);
             };
 
-        /// <summary> Function for finding sealed classes. </summary>
+        /// <summary>
+        /// Function for finding sealed classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeSealed = 
             delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
             {
                 return input.Where(c => c.IsSealed == condition);
             };
 
-        /// <summary> Function for finding immutable classes. </summary>
+        /// <summary>
+        /// Function for finding immutable classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> BeImmutable = 
             delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
             {
                 return input.Where(c => c.IsImmutable() == condition);
             };
 
-        /// <summary> Function for finding nullable classes. </summary>
+        /// <summary>
+        /// Function for finding nullable classes.
+        /// </summary>
         internal static readonly FunctionDelegate<bool> HasNullableMembers = 
             delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
             {
                 return input.Where(c => c.HasNullableMembers() == condition);
             };
 
-        /// <summary> Function for finding types in a particular namespace. </summary>
+        /// <summary>
+        /// Function for finding types in a particular namespace.
+        /// </summary>
         internal static readonly FunctionDelegate<string> ResideInNamespace = 
             delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
             {
@@ -213,7 +257,9 @@ namespace NetArchTest.Rules
                     c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase) == condition);
             };
 
-        /// <summary> Function for matching a type name using a regular expression. </summary>
+        /// <summary>
+        /// Function for matching a type name using a regular expression.
+        /// </summary>
         internal static readonly FunctionDelegate<string> ResideInNamespaceMatching = 
             delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
             {
@@ -222,7 +268,9 @@ namespace NetArchTest.Rules
                 return input.Where(c => r.Match(c.GetNamespace()).Success == condition);
             };
 
-        /// <summary> Function for finding types that have a dependency on any of the supplied types. </summary>
+        /// <summary>
+        /// Function for finding types that have a dependency on any of the supplied types.
+        /// </summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = 
             delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
             {
@@ -236,7 +284,9 @@ namespace NetArchTest.Rules
                     : typeDefinitions.Except(matchingTypes);
             };
 
-        /// <summary> Function for finding types that have a dependency on all of the supplied types. </summary>
+        /// <summary>
+        /// Function for finding types that have a dependency on all of the supplied types.
+        /// </summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = 
             delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
             {
@@ -250,7 +300,9 @@ namespace NetArchTest.Rules
                     : typeDefinitions.Except(matchingTypes);
             };
 
-        /// <summary> Function for finding types that have a dependency on type other than one of the supplied types.</summary>
+        /// <summary>
+        /// Function for finding types that have a dependency on type other than one of the supplied types.
+        /// </summary>
         internal static readonly FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = 
             delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
             {
@@ -264,7 +316,9 @@ namespace NetArchTest.Rules
                     : typeDefinitions.Except(matchingTypes);
             };
 
-        /// <summary> Function for finding public classes. </summary>
+        /// <summary>
+        /// Function for finding public classes.
+        /// </summary>
         internal static readonly FunctionDelegate<ICustomRule> MeetCustomRule = 
             delegate (IEnumerable<TypeDefinition> input, ICustomRule rule, bool condition)
             {

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -95,7 +95,6 @@ namespace NetArchTest.Rules
                     ) == condition);
             };
 
-
         /// <summary>
         /// Function for finding classes that inherit from a particular type.
         /// </summary>
@@ -180,7 +179,6 @@ namespace NetArchTest.Rules
             {
                 return input.Where(c => c.HasGenericParameters == condition);
             };
-
 
         /// <summary>
         /// Function for finding nested classes.

--- a/src/NetArchTest.Rules/FunctionDelegates.cs
+++ b/src/NetArchTest.Rules/FunctionDelegates.cs
@@ -22,224 +22,253 @@ namespace NetArchTest.Rules
         internal delegate IEnumerable<TypeDefinition> FunctionDelegate<T>(IEnumerable<TypeDefinition> input, T arg, bool condition);
 
         /// <summary> Function for finding a specific type name. </summary>
-        internal static readonly FunctionDelegate<string> HaveName = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
-        {
-            return input.Where(c => 
-                c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) == condition);
-        };
+        internal static readonly FunctionDelegate<string> HaveName = 
+            delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
+            {
+                return input.Where(c => 
+                    c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase) == condition);
+            };
 
         /// <summary> Function for matching a type name using a regular expression. </summary>
-        internal static readonly FunctionDelegate<string> HaveNameMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
-        {
-            var r = new Regex(pattern, RegexOptions.IgnoreCase);
-            
-            return input.Where(c => r.Match(c.Name).Success == condition);
-        };
+        internal static readonly FunctionDelegate<string> HaveNameMatching = 
+            delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
+            {
+                var r = new Regex(pattern, RegexOptions.IgnoreCase);
+                
+                return input.Where(c => r.Match(c.Name).Success == condition);
+            };
 
         /// <summary> Function for matching the start of a type name. </summary>
-        internal static readonly FunctionDelegate<string> HaveNameStartingWith = MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison.InvariantCultureIgnoreCase);
+        internal static readonly FunctionDelegate<string> HaveNameStartingWith = 
+            MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison.InvariantCultureIgnoreCase);
 
-        internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison comparer) => delegate (IEnumerable<TypeDefinition> input, string start, bool condition)
-        {
-            return input.Where(c => c.Name.StartsWith(start, comparer) == condition);
-        };
+        internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameStartingWith(StringComparison comparer) 
+            => delegate (IEnumerable<TypeDefinition> input, string start, bool condition) 
+            {
+                return input.Where(c => c.Name.StartsWith(start, comparer) == condition);
+            };
 
         /// <summary> Function for matching the end of a type name. </summary>
-        internal static readonly FunctionDelegate<string> HaveNameEndingWith = MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison.InvariantCultureIgnoreCase);
+        internal static readonly FunctionDelegate<string> HaveNameEndingWith = 
+            MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison.InvariantCultureIgnoreCase);
 
-        internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison comparer) => delegate (IEnumerable<TypeDefinition> input, string end, bool condition)
-        {
-            return input.Where(c => c.Name.EndsWith(end, comparer) == condition);
-        };
+        internal static FunctionDelegate<string> MakeFunctionDelegateUsingStringComparerForHaveNameEndingWith(StringComparison comparer) 
+            => delegate (IEnumerable<TypeDefinition> input, string end, bool condition)
+            {
+                return input.Where(c => c.Name.EndsWith(end, comparer) == condition);
+            };
 
         /// <summary> Function for finding classes with a particular custom attribute. </summary>
-        internal static readonly FunctionDelegate<Type> HaveCustomAttribute = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
-        {
-            return input.Where(c => 
-                c.CustomAttributes.Any(a => 
-                    attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
-                == condition);
-        };
+        internal static readonly FunctionDelegate<Type> HaveCustomAttribute = 
+            delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
+            {
+                return input.Where(c => 
+                    c.CustomAttributes.Any(a => 
+                        attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    == condition);
+            };
 
         /// <summary> Function for finding classes decorated with a particular custom attribute or derived one</summary>
-        internal static readonly FunctionDelegate<Type> HaveCustomAttributeOrInherit = delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
-        {
-            var target = attribute.ToTypeDefinition();
-
-            return input.Where(c => 
-                c.CustomAttributes.Any(a => 
-                    a.AttributeType.Resolve().IsSubclassOf(target) || (attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
-                ) == condition);
-        };
+        internal static readonly FunctionDelegate<Type> HaveCustomAttributeOrInherit = 
+            delegate (IEnumerable<TypeDefinition> input, Type attribute, bool condition)
+            {
+                var target = attribute.ToTypeDefinition();
+                
+                return input.Where(c => 
+                    c.CustomAttributes.Any(a => 
+                        a.AttributeType.Resolve().IsSubclassOf(target) 
+                        || (attribute.FullName?.Equals(a.AttributeType.FullName, StringComparison.InvariantCultureIgnoreCase) ?? false)
+                    ) == condition);
+            };
 
 
         /// <summary> Function for finding classes that inherit from a particular type. </summary>
-        internal static readonly FunctionDelegate<Type> Inherits = delegate (IEnumerable<TypeDefinition> input, Type type, bool condition)
-        {
-            var target = type.ToTypeDefinition();
+        internal static readonly FunctionDelegate<Type> Inherits = 
+            delegate (IEnumerable<TypeDefinition> input, Type type, bool condition)
+            {
+                var target = type.ToTypeDefinition();
 
-            return input.Where(c => c.IsSubclassOf(target) == condition);
-        };
+                return input.Where(c => c.IsSubclassOf(target) == condition);
+            };
 
         /// <summary> Function for finding classes that implement a particular interface. </summary>
-        internal static readonly FunctionDelegate<Type> ImplementsInterface = delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
-        {
-            if (!typeInterface.IsInterface)
+        internal static readonly FunctionDelegate<Type> ImplementsInterface = 
+            delegate (IEnumerable<TypeDefinition> input, Type typeInterface, bool condition)
             {
-                throw new ArgumentException($"The type {typeInterface.FullName} is not an interface.");
-            }
+                if (!typeInterface.IsInterface)
+                {
+                    throw new ArgumentException($"The type {typeInterface.FullName} is not an interface.");
+                }
             
-            var typeDefinitions = input.ToList();
-            var target = typeInterface.FullName;
+                var typeDefinitions = input.ToList();
+                var target = typeInterface.FullName;
 
-            var matchingTypes = typeDefinitions
-                .Where(t => t.Interfaces.Any(i =>
-                    i.InterfaceType.Resolve().FullName.Equals(target, StringComparison.InvariantCultureIgnoreCase)));
+                var matchingTypes = typeDefinitions
+                    .Where(t => t.Interfaces.Any(i =>
+                        i.InterfaceType.Resolve().FullName.Equals(target, StringComparison.InvariantCultureIgnoreCase)));
 
-            return condition
-                ? matchingTypes
-                : typeDefinitions.Except(matchingTypes);
-        };
+                return condition
+                    ? matchingTypes
+                    : typeDefinitions.Except(matchingTypes);
+            };
 
         /// <summary> Function for finding abstract classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeAbstract = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsAbstract == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeAbstract = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsAbstract == condition);
+            };
 
         /// <summary> Function for finding classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeClass = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsClass == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeClass = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsClass == condition);
+            };
 
         /// <summary> Function for finding interfaces. </summary>
-        internal static readonly FunctionDelegate<bool> BeInterface = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsInterface == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeInterface = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsInterface == condition);
+            };
 
         /// <summary> Function for finding static classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeStatic = delegate(IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => ClassIsStatic(c) == condition);
+        internal static readonly FunctionDelegate<bool> BeStatic = 
+            delegate(IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => ClassIsStatic(c) == condition);
 
-            bool ClassIsStatic(TypeDefinition c) => 
-                c.IsAbstract 
-                && c.IsSealed 
-                && !c.IsInterface 
-                && !c.GetConstructors().Any(m => m.IsPublic);
-        };
+                bool ClassIsStatic(TypeDefinition c) => 
+                    c.IsAbstract 
+                    && c.IsSealed 
+                    && !c.IsInterface 
+                    && !c.GetConstructors().Any(m => m.IsPublic);
+            };
 
         /// <summary> Function for finding types with generic parameters. </summary>
-        internal static readonly FunctionDelegate<bool> BeGeneric = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.HasGenericParameters == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeGeneric = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.HasGenericParameters == condition);
+            };
 
 
         /// <summary> Function for finding nested classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeNested = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsNested == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeNested = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsNested == condition);
+            };
 
         /// <summary> Function for finding nested public classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeNestedPublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsNestedPublic == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeNestedPublic = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsNestedPublic == condition);
+            };
 
         /// <summary> Function for finding nested private classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeNestedPrivate = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return input.Where(c => c.IsNestedPrivate == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeNestedPrivate = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return input.Where(c => c.IsNestedPrivate == condition);
+            };
 
         /// <summary> Function for finding public classes. </summary>
-        internal static readonly FunctionDelegate<bool> BePublic = delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
-        {
-            return condition 
-                ? input.Where(c => c.IsNested ? c.IsNestedPublic : c.IsPublic)
-                : input.Where(c => c.IsNested ? !c.IsNestedPublic : c.IsNotPublic);
-        };
+        internal static readonly FunctionDelegate<bool> BePublic = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummy, bool condition)
+            {
+                return condition 
+                    ? input.Where(c => c.IsNested ? c.IsNestedPublic : c.IsPublic)
+                    : input.Where(c => c.IsNested ? !c.IsNestedPublic : c.IsNotPublic);
+            };
 
         /// <summary> Function for finding sealed classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeSealed = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
-        {
-            return input.Where(c => c.IsSealed == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeSealed = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            {
+                return input.Where(c => c.IsSealed == condition);
+            };
 
         /// <summary> Function for finding immutable classes. </summary>
-        internal static readonly FunctionDelegate<bool> BeImmutable = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
-        {
-            return input.Where(c => c.IsImmutable() == condition);
-        };
+        internal static readonly FunctionDelegate<bool> BeImmutable = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            {
+                return input.Where(c => c.IsImmutable() == condition);
+            };
 
         /// <summary> Function for finding nullable classes. </summary>
-        internal static readonly FunctionDelegate<bool> HasNullableMembers = delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
-        {
-            return input.Where(c => c.HasNullableMembers() == condition);
-        };
+        internal static readonly FunctionDelegate<bool> HasNullableMembers = 
+            delegate (IEnumerable<TypeDefinition> input, bool dummmy, bool condition)
+            {
+                return input.Where(c => c.HasNullableMembers() == condition);
+            };
 
         /// <summary> Function for finding types in a particular namespace. </summary>
-        internal static readonly FunctionDelegate<string> ResideInNamespace = delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
-        {
-            return input.Where(c => 
-                c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase) == condition);
-        };
+        internal static readonly FunctionDelegate<string> ResideInNamespace = 
+            delegate (IEnumerable<TypeDefinition> input, string name, bool condition)
+            {
+                return input.Where(c => 
+                    c.FullName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase) == condition);
+            };
 
         /// <summary> Function for matching a type name using a regular expression. </summary>
-        internal static readonly FunctionDelegate<string> ResideInNamespaceMatching = delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
-        {
-            var r = new Regex(pattern, RegexOptions.IgnoreCase);
+        internal static readonly FunctionDelegate<string> ResideInNamespaceMatching = 
+            delegate (IEnumerable<TypeDefinition> input, string pattern, bool condition)
+            {
+                var r = new Regex(pattern, RegexOptions.IgnoreCase);
             
-            return input.Where(c => r.Match(c.GetNamespace()).Success == condition);
-        };
+                return input.Where(c => r.Match(c.GetNamespace()).Success == condition);
+            };
 
         /// <summary> Function for finding types that have a dependency on any of the supplied types. </summary>
-        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
-        {
-            var typeDefinitions = input.ToList();
+        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAny = 
+            delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+            {
+                var typeDefinitions = input.ToList();
             
-            var search = new DependencySearch();
-            var matchingTypes = search.FindTypesThatHaveDependencyOnAny(typeDefinitions, dependencies);
+                var search = new DependencySearch();
+                var matchingTypes = search.FindTypesThatHaveDependencyOnAny(typeDefinitions, dependencies);
 
-            return condition
-                ? matchingTypes
-                : typeDefinitions.Except(matchingTypes);
-        };
+                return condition
+                    ? matchingTypes
+                    : typeDefinitions.Except(matchingTypes);
+            };
 
         /// <summary> Function for finding types that have a dependency on all of the supplied types. </summary>
-        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
-        {
-            var typeDefinitions = input.ToList();
+        internal static readonly FunctionDelegate<IEnumerable<string>> HaveDependencyOnAll = 
+            delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+            {
+                var typeDefinitions = input.ToList();
             
-            var search = new DependencySearch();
-            var matchingTypes = search.FindTypesThatHaveDependencyOnAll(typeDefinitions, dependencies);
+                var search = new DependencySearch();
+                var matchingTypes = search.FindTypesThatHaveDependencyOnAll(typeDefinitions, dependencies);
 
-            return condition
-                ? matchingTypes
-                : typeDefinitions.Except(matchingTypes);
-        };
+                return condition
+                    ? matchingTypes
+                    : typeDefinitions.Except(matchingTypes);
+            };
 
         /// <summary> Function for finding types that have a dependency on type other than one of the supplied types.</summary>
-        internal static readonly FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
-        {
-            var typeDefinitions = input.ToList();
+        internal static readonly FunctionDelegate<IEnumerable<string>> OnlyHaveDependenciesOnAnyOrNone = 
+            delegate (IEnumerable<TypeDefinition> input, IEnumerable<string> dependencies, bool condition)
+            {
+                var typeDefinitions = input.ToList();
             
-            var search = new DependencySearch();
-            var matchingTypes = search.FindTypesThatOnlyHaveDependenciesOnAnyOrNone(typeDefinitions, dependencies);
+                var search = new DependencySearch();
+                var matchingTypes = search.FindTypesThatOnlyHaveDependenciesOnAnyOrNone(typeDefinitions, dependencies);
 
-            return condition
-                ? matchingTypes
-                : typeDefinitions.Except(matchingTypes);
-        };
+                return condition
+                    ? matchingTypes
+                    : typeDefinitions.Except(matchingTypes);
+            };
 
         /// <summary> Function for finding public classes. </summary>
-        internal static readonly FunctionDelegate<ICustomRule> MeetCustomRule = delegate (IEnumerable<TypeDefinition> input, ICustomRule rule, bool condition)
-        {
-            return input.Where(t => rule.MeetsRule(t) == condition);
-        };
+        internal static readonly FunctionDelegate<ICustomRule> MeetCustomRule = 
+            delegate (IEnumerable<TypeDefinition> input, ICustomRule rule, bool condition)
+            {
+                return input.Where(t => rule.MeetsRule(t) == condition);
+            };
     }
 }


### PR DESCRIPTION
Some refactorings in the FunctionDelegates.cs.

Changes:
- break summaries to multiple lines
- break delegate definitions to new line (readability)
- resolve multiple enumeration issue

All Unit Tests executed successfully.

Independent, not related to #112 