### PR TITLE
Refactoring: Nesting & Style

### DIFF
--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -78,6 +78,5 @@
             _sequence.CreateGroup();
             return new Predicates(_types, _sequence);
         }
-
     }
 }

--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -11,10 +11,14 @@
     /// </summary>
     public sealed class PredicateList
     {
-        /// <summary> A list of types that conditions can be applied to. </summary>
+        /// <summary>
+        /// A list of types that conditions can be applied to.
+        /// </summary>
         private readonly IEnumerable<TypeDefinition> _types;
 
-        /// <summary> The sequence of conditions that is applied to the type of list. </summary>
+        /// <summary>
+        /// The sequence of conditions that is applied to the type of list.
+        /// </summary>
         private readonly FunctionSequence _sequence;
 
         /// <summary>

--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -7,7 +7,8 @@
     using Mono.Cecil;
 
     /// <summary>
-    /// A set of predicates and types that have have conjunctions (i.e. "and", "or") and executors (i.e. Types(), TypeDefinitions()) applied to them.
+    /// A set of predicates and types that have have conjunctions (i.e. "and", "or")
+    /// and executors (i.e. Types(), TypeDefinitions()) applied to them.
     /// </summary>
     public sealed class PredicateList
     {
@@ -35,36 +36,29 @@
         /// </summary>
         /// <returns>A condition that tests classes against a given criteria.</returns>
         public Conditions Should()
-        {
-            return new Conditions(_sequence.Execute(_types), true);
-        }
+            => new Conditions(_sequence.Execute(_types), true);
 
         /// <summary>
         /// Links a predicate defining a set of classes to a condition that tests them.
         /// </summary>
         /// <returns>A condition that tests classes against a given criteria.</returns>
         public Conditions ShouldNot()
-        {
-            return new Conditions(_sequence.Execute(_types), false);
-        }
+            => new Conditions(_sequence.Execute(_types), false);
 
         /// <summary>
         /// Returns the type definitions returned by these predicate.
         /// </summary>
         /// <returns>A list of type definitions.</returns>
         internal IEnumerable<TypeDefinition> GetTypeDefinitions()
-        { 
-            return _sequence.Execute(_types);
-        }
+            => _sequence.Execute(_types);
 
         /// <summary>
         /// Returns the types returned by these predicates.
         /// </summary>
         /// <returns>A list of types.</returns>
         public IEnumerable<Type> GetTypes()
-        {
-            return _sequence.Execute(_types).Select(t => t.ToType());
-        }
+            => _sequence.Execute(_types)
+                .Select(t => t.ToType());
 
         /// <summary>
         /// Specifies that any subsequent predicates should be treated as "and" conditions.
@@ -72,9 +66,7 @@
         /// <returns>An set of predicates that can be applied to a list of classes.</returns>
         /// <remarks>And() has higher priority than Or() and it is computed first.</remarks>
         public Predicates And()
-        {
-            return new Predicates(_types, _sequence);
-        }
+            => new Predicates(_types, _sequence);
 
         /// <summary>
         /// Specifies that any subsequent predicates should be treated as part of an "or" condition.

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -49,6 +49,7 @@
             {
                 _sequence.AddFunctionCall(FunctionDelegates.HaveName, item, true);
             }
+            
             return new PredicateList(_types, _sequence);
         }
 
@@ -63,6 +64,7 @@
             {
                 _sequence.AddFunctionCall(FunctionDelegates.HaveName, item, false);
             }
+            
             return new PredicateList(_types, _sequence);
         }
 
@@ -99,6 +101,7 @@
             {
                 _sequence.AddFunctionCall(FunctionDelegates.HaveNameStartingWith, item, true);
             }
+            
             return new PredicateList(_types, _sequence);
         }
 
@@ -125,6 +128,7 @@
             {
                 _sequence.AddFunctionCall(FunctionDelegates.HaveNameStartingWith, item, false);
             }
+            
             return new PredicateList(_types, _sequence);
         }
 
@@ -435,7 +439,6 @@
             _sequence.AddFunctionCall(FunctionDelegates.BeNestedPrivate, true, false);
             return new PredicateList(_types, _sequence);
         }
-
 
         /// <summary>
         /// Selects types that have public scope.

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using NetArchTest.Rules.Extensions;
     using Mono.Cecil;
 
     /// <summary>

--- a/src/NetArchTest.Rules/Predicates.cs
+++ b/src/NetArchTest.Rules/Predicates.cs
@@ -11,10 +11,14 @@
     /// </summary>
     public sealed class Predicates
     {
-        /// <summary> A list of types that conditions can be applied to. </summary>
+        /// <summary>
+        /// A list of types that conditions can be applied to.
+        /// </summary>
         private readonly IEnumerable<TypeDefinition> _types;
 
-        /// <summary> The sequence of conditions that is applied to the type of list. </summary>
+        ///<summary>
+        /// The sequence of conditions that is applied to the type of list.
+        /// </summary>
         private readonly FunctionSequence _sequence;
 
         /// <summary>

--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -11,7 +11,9 @@
     /// </summary>
     public sealed class TestResult
     {
-        /// <summary> The list of types that failed the test. </summary>
+        /// <summary>
+        /// The list of types that failed the test.
+        /// </summary>
         private IReadOnlyList<TypeDefinition> _failingTypes;
 
         private TestResult()

--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -41,7 +41,6 @@
         public IReadOnlyList<string> FailingTypeNames
             => _failingTypes?.Select(t => t.FullName).ToList();
 
-
         /// <summary>
         /// Creates a new instance of <see cref="TestResult"/> indicating a successful test.
         /// </summary>

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -278,45 +278,35 @@
         /// </summary>
         /// <returns>The list of <see cref="TypeDefinition"/> objects in this list.</returns>
         internal IEnumerable<TypeDefinition> GetTypeDefinitions()
-        {
-            return _types;
-        }
+            => _types;
 
         /// <summary>
         /// Returns the list of <see cref="Type"/> objects describing the types in this list.
         /// </summary>
         /// <returns>The list of <see cref="Type"/> objects in this list.</returns>
         public IEnumerable<Type> GetTypes()
-        {
-            return (_types.Select(t => t.ToType()));
-        }
+            => _types.Select(t => t.ToType());
 
         /// <summary>
         /// Allows a list of types to be applied to one or more filters.
         /// </summary>
         /// <returns>A list of types onto which you can apply a series of filters.</returns>
         public Predicates That()
-        {
-            return new Predicates(_types);
-        }
+            => new Predicates(_types);
 
         /// <summary>
         /// Applies a set of conditions to the list of types.
         /// </summary>
         /// <returns></returns>
         public Conditions Should()
-        {
-            return new Conditions(_types, true);
-        }
+            => new Conditions(_types, true);
 
         /// <summary>
         /// Applies a negative set of conditions to the list of types.
         /// </summary>
         /// <returns></returns>
         public Conditions ShouldNot()
-        {
-            return new Conditions(_types, false);
-        }
+            => new Conditions(_types, false);
 
         /// <summary>
         /// Reads the assembly, ignoring a BadImageFormatException

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -8,7 +8,6 @@
     using System.Runtime.CompilerServices;
     using NetArchTest.Rules.Extensions;
     using Mono.Cecil;
-    using NetArchTest.Rules.Dependencies;
     using NetArchTest.Rules.Dependencies.DataStructures;
 
     /// <summary>

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -53,7 +53,7 @@
                 }
             }
 
-            return Types.InAssemblies(currentDomain);
+            return InAssemblies(currentDomain);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@
                 throw new ArgumentNullException(nameof(assembly));
             }
 
-            return Types.InAssemblies(new List<Assembly> { assembly }, searchDirectories);
+            return InAssemblies(new List<Assembly> { assembly }, searchDirectories);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@
                     // Read all the types in the assembly 
                     if (assemblyDef != null)
                     {
-                        types.AddRange(Types.GetAllTypes(assemblyDef.Modules.SelectMany(t => t.Types)));
+                        types.AddRange(GetAllTypes(assemblyDef.Modules.SelectMany(t => t.Types)));
                     }
                 }
             }
@@ -155,7 +155,7 @@
                 }
             }
 
-            var list = Types.GetAllTypes(types);
+            var list = GetAllTypes(types);
             return new Types(list);
         }
 
@@ -186,7 +186,7 @@
             if (assemblyDef != null)
             {
                 // Read all the types in the assembly 
-                var list = Types.GetAllTypes(assemblyDef.Modules.SelectMany(t => t.Types));
+                var list = GetAllTypes(assemblyDef.Modules.SelectMany(t => t.Types));
                 return new Types(list);
             }
             else
@@ -243,7 +243,7 @@
                 throw new DirectoryNotFoundException($"Could not find the path {path}.");
             }
 
-            var list = Types.GetAllTypes(types);
+            var list = GetAllTypes(types);
             return new Types(list);
         }
 

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -40,6 +40,7 @@
         public static Types InCurrentDomain()
         {
             var currentDomain = new List<Assembly>();
+            
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (!_exclusionTree.GetAllMatchingNames(assembly.FullName).Any())                   
@@ -170,10 +171,12 @@
             // Load the assembly from the current directory
             var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var path = Path.Combine(dir, filename);
+            
             if (!File.Exists(path))
             {
                 throw new FileNotFoundException($"Could not find the assembly file {path}.");
             }
+            
             var assemblyDef = ReadAssemblyDefinition(path);
 
             if (assemblyDef != null)
@@ -212,10 +215,12 @@
                 if (searchDirectories?.Any() ?? false)
                 {
                     var defaultAssemblyResolver = new DefaultAssemblyResolver();
+                    
                     foreach (var searchDirectory in searchDirectories)
                     {
                         defaultAssemblyResolver.AddSearchDirectory(searchDirectory);
                     }
+                    
                     readerParams.AssemblyResolver = defaultAssemblyResolver;
                 }
 

--- a/src/NetArchTest.Rules/Types.cs
+++ b/src/NetArchTest.Rules/Types.cs
@@ -15,10 +15,14 @@
     /// </summary>
     public sealed class Types
     {
-        /// <summary> The list of types represented by this instance. </summary>
+        /// <summary>
+        /// The list of types represented by this instance.
+        /// </summary>
         private readonly List<TypeDefinition> _types;
 
-        /// <summary> The list of namespaces to exclude from the current domain. </summary>
+        /// <summary>
+        /// The list of namespaces to exclude from the current domain.
+        /// </summary>
         private static readonly List<string> _exclusionList = new List<string>
         { "System", "Microsoft", "Mono.Cecil", "netstandard", "NetArchTest.Rules", "<Module>", "xunit", "<PrivateImplementationDetails>" };
 


### PR DESCRIPTION
Some refactorings in Predicate.cs, PredicateList.cs, TestResult.cs, Types.cs.

Changes:
- use expression method style if one liner
- break summaries
- remove nesting
- remove unnecessary usings
- add / remove new lines

All Unit Tests executed successfully.

Independent from other PRs