### PR TITLE
Fixed nulls for Success result

### DIFF
--- a/src/NetArchTest.Rules/TestResult.cs
+++ b/src/NetArchTest.Rules/TestResult.cs
@@ -49,7 +49,8 @@
         internal static TestResult Success()
             => new TestResult
             {
-                IsSuccessful = true
+                IsSuccessful = true,
+                _failingTypes = new List<TypeDefinition>(0),
             };
 
         /// <summary>

--- a/test/NetArchTest.Rules.UnitTests/ConditionListTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionListTests.cs
@@ -143,8 +143,8 @@
             Assert.Contains<Type>(typeof(ClassA3), result.FailingTypes);
         }
 
-        [Fact(DisplayName = "If a condition succeeds then a list of failing types should be null.")]
-        public void GetResult_Success_ReturnNullFailedTypes()
+        [Fact(DisplayName = "If a condition succeeds then a list of failing types should be empty.")]
+        public void GetResult_Success_ReturnEmptyFailedTypes()
         {
             var result = Types
                 .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
@@ -161,7 +161,8 @@
                 .GetResult();
 
             Assert.True(result.IsSuccessful);
-            Assert.Null(result.FailingTypes);
+            Assert.NotNull(result.FailingTypes);
+            Assert.Empty(result.FailingTypes);
         }
     }
 }


### PR DESCRIPTION
Collections should never return `null`. Better value for collection is just empty collection.
As a reference, you can take API - collection endpoints never return `null`, but empty array (`[]`).

---
Null cause problems, ie I can't do like this `Assert.True(result.IsSuccessful, $"Failing Types: {string.Join("; ", result.FailingTypeNames)}");`, I need `Assert.True(result.IsSuccessful, $"Failing Types: {string.Join("; ", result.FailingTypeNames ?? Array.Empty<string>())}");` ([reference](https://github.com/lkurzyniec/netcore-boilerplate/blob/master/test/HappyCode.NetCoreBoilerplate.ArchitecturalTests/CoreArchitecturalTests.cs)).