### PR TITLE
Add GetTypeNames variant of getting the Types for ConditionList and PredicateList

### DIFF
--- a/src/NetArchTest.Rules/ConditionList.cs
+++ b/src/NetArchTest.Rules/ConditionList.cs
@@ -77,6 +77,15 @@
             => _sequence.Execute(_types).Select(t => t.ToType());
 
         /// <summary>
+        /// Returns the list of type names that satisfy the conditions.
+        /// </summary>
+        /// <remarks>
+        /// This is a "safer" way of getting a list of types that satisfy the conditions as it does not load the types when enumerating the list. This can lead to dependency loading errors.
+        /// </remarks>
+        public IEnumerable<string> GetTypeNames()
+            => _sequence.Execute(_types).Select(t => t.FullName);
+
+        /// <summary>
         /// Specifies that any subsequent condition should be treated as an "and" condition.
         /// </summary>
         /// <returns>An set of conditions that can be applied to a list of classes.</returns>

--- a/src/NetArchTest.Rules/PredicateList.cs
+++ b/src/NetArchTest.Rules/PredicateList.cs
@@ -61,6 +61,15 @@
                 .Select(t => t.ToType());
 
         /// <summary>
+        /// Returns the list of type names returned by these predicates.
+        /// </summary>
+        /// <remarks>
+        /// This is a "safer" way of getting a list of types returned by these predicates as it does not load the types when enumerating the list. This can lead to dependency loading errors.
+        /// </remarks>
+        public IEnumerable<string> GetTypeNames()
+            => _sequence.Execute(_types).Select(t => t.FullName);
+
+        /// <summary>
         /// Specifies that any subsequent predicates should be treated as "and" conditions.
         /// </summary>
         /// <returns>An set of predicates that can be applied to a list of classes.</returns>

--- a/test/NetArchTest.Rules.UnitTests/ConditionListTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/ConditionListTests.cs
@@ -163,5 +163,29 @@
             Assert.True(result.IsSuccessful);
             Assert.Null(result.FailingTypes);
         }
+
+        [Fact(DisplayName = "GetTypeNames should work whenever GetTypes could be used on a ConditionList.")]
+        public void GetTypeNames_Success_AnyConditions()
+        {
+            // Same as test "Or_AppliedToConditions_SelectCorrectTypes" but with Type Names verification
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.NameMatching")
+                .Should()
+                .HaveNameStartingWith("ClassA")
+                .Or()
+                .HaveNameEndingWith("1")
+                .Or()
+                .HaveNameEndingWith("2")
+                .GetTypeNames();
+
+            Assert.Equal(5, result.Count()); // five types found
+            Assert.Contains(typeof(ClassA1).FullName, result);
+            Assert.Contains(typeof(ClassA2).FullName, result);
+            Assert.Contains(typeof(ClassA3).FullName, result);
+            Assert.Contains(typeof(ClassB1).FullName, result);
+            Assert.Contains(typeof(ClassB2).FullName, result);
+        }
     }
 }

--- a/test/NetArchTest.Rules.UnitTests/PredicateListTests.cs
+++ b/test/NetArchTest.Rules.UnitTests/PredicateListTests.cs
@@ -76,5 +76,28 @@
             Assert.Contains<Type>(typeof(ClassB2), result);
         }
 
+        [Fact(DisplayName = "GetTypeNames should work whenever GetTypes could be used on a PredicateList.")]
+        public void GetTypeNames_Success_AnyConditions()
+        {
+            // Same as test "Or_AppliedToPredicates_SelectCorrectTypes" but with Type Names verification
+            var result = Types
+                .InAssembly(Assembly.GetAssembly(typeof(ClassA1)))
+                .That()
+                .ResideInNamespace("NetArchTest.TestStructure.NameMatching.Namespace1")
+                .Or()
+                .ResideInNamespace("NetArchTest.TestStructure.NameMatching.Namespace2")
+                .Or()
+                .ResideInNamespace("NetArchTest.TestStructure.Generic")
+                .GetTypeNames();
+
+            Assert.Equal(7, result.Count()); // seven types found
+            Assert.Contains(typeof(ClassA1).FullName, result);
+            Assert.Contains(typeof(ClassA2).FullName, result);
+            Assert.Contains(typeof(ClassA3).FullName, result);
+            Assert.Contains(typeof(ClassB1).FullName, result);
+            Assert.Contains(typeof(ClassB2).FullName, result);
+            Assert.Contains(typeof(GenericType<>).FullName, result);
+            Assert.Contains(typeof(NonGenericType).FullName, result);
+        }
     }
 }


### PR DESCRIPTION
When working with externally loaded Assemblies, using `GetTypes()` on `ConditionList` or `PredicateList` will fail, because the Types won't be loaded into the current App domain. To be able to safely work with the intermediate results as you'd normally do with `GetTypes()` (e.g. to be able to extract lists for further usage in e. g. `HaveDependencyOn()`) the Method `GetTypeNames()` which is currently only available on `TestResult` level, does come very handy.

Implemented `GetTypeNames()` on `ConditionList` or `PredicateList`.

As for testing, I only implemented a sample "any" test for a random condition.